### PR TITLE
Add prismjs syntax highlighter

### DIFF
--- a/fox.jason.prismjs.json
+++ b/fox.jason.prismjs.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "fox.jason.prismjs",
+    "description": "An integration of Prism-JS into the DITA Open Toolkit engine, enabling static HTML and PDF syntax highlighting.",
+    "keywords": ["prismjs", "code-highlighter", "syntax-highlighting"],
+    "homepage": "https://jason-fox.github.io/fox.jason.prismjs",
+    "vers": "1.0.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.1.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.prismjs/archive/v1.0.0.zip",
+    "cksum": "4992de9982a016bc97e11bc939b9df8d57800526bd3c93a68d3c1ba96a80c93f"
+  }
+]


### PR DESCRIPTION
Every feel your DITA `<codeblock>` snippets are a little drab? Why not add a syntax highlighter?

> ![](https://jason-fox.github.io/fox.jason.prismjs/highlighted.png)

This is a syntax highlighting DITA-OT Plug-in which integrates the flexible [Prism-JS](https://github.com/PrismJS/prism) highlighting library into the DITA Open Toolkit engine. This enables the generation of documents including code snippets which are automatically colorized according to language syntax. The plug-in extends both static HTML and PDF transtypes.