### PR TITLE
Add deprecated-dita plugin to registry

### DIFF
--- a/org.metadita.deprecated.json
+++ b/org.metadita.deprecated.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "org.metadita.deprecated",
+    "description": "Report markup deprecated for DITA 2.0",
+    "keywords": ["deprecated", "validation", "OASIS"],
+    "homepage": "https://github.com/robander/deprecated-dita/",
+    "vers": "1.0.0",
+    "license": "Apache 2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.3"
+      }
+    ],
+    "url": "https://github.com/robander/deprecated-dita/releases/download/1.0/org.metadita.deprecated-1.0.zip",
+    "cksum": "5C2119D4360B234CE91F4AC7739313BCB4104E1AF12EE2542831BCC02B515B72"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Add `org.metadita.deprecated` plugin to the registry. 

Purpose of the plug-in is to log a warning (after `preprocess` or `preprocess2`) for any markup that is deprecated in DITA 1.x and will be removed in DITA 2.0.

Tested by adding `https://raw.githubusercontent.com/robander/registry/deprecated.dita/` to registry configuration, and installing to 3.3 with
`bin/dita --install org.metadita.deprecated`