### PR TITLE
Updating plugins to 3.x support

### DIFF
--- a/com.here.validate.svrl.json
+++ b/com.here.validate.svrl.json
@@ -14,5 +14,21 @@
     ],
     "url": "https://github.com/jason-fox/com.here.validate.svrl/archive/v2.0.2.zip",
     "cksum": "57a7db08366935a8554a25a82bb4d0a73f73f3f2e6048ed19c970747ce97c320"
+  },
+  {
+    "name": "com.here.validate.svrl",
+    "description": "A structure, style and content linter for DITA, MDITA and Markdown documents.",
+    "keywords": ["validation", "lint"],
+    "homepage": "https://jason-fox.github.io/com.here.validate.svrl",
+    "vers": "3.0.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/com.here.validate.svrl/archive/v3.0.0.zip",
+    "cksum": "4416550b4e9baf0d7efae6ce19145631a0bdd4aebf3f230112293026cb2a67b9"
   }
 ]

--- a/com.here.validate.svrl.overrides.json
+++ b/com.here.validate.svrl.overrides.json
@@ -18,5 +18,25 @@
     ],
     "url": "https://github.com/jason-fox/com.here.validate.svrl.overrides/archive/v2.0.1.zip",
     "cksum": "e2e700d6936b4ff238b5711c40601e396c040ee3a31426fe97eba3702a11754a"
+  },
+  {
+    "name": "com.here.validate.svrl.overrides",
+    "description": "Shows how to add, remove or extend the ruleset of the base DITA Validator (com.here.validate.svrl).",
+    "keywords": ["validation", "lint"],
+    "homepage": "https://github.com/jason-fox/com.here.validate.svrl.overrides/blob/master/README.md",
+    "vers": "3.0.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "com.here.validate.svrl",
+        "req": ">=3.0.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/com.here.validate.svrl.overrides/archive/v3.0.0.zip",
+    "cksum": "bb5c69ce4b80daeb618743c373cbe2f23fdb2a061e76e913ba38dd4b1cdaf47b"
   }
 ]

--- a/com.here.validate.svrl.text-rules.json
+++ b/com.here.validate.svrl.text-rules.json
@@ -18,5 +18,25 @@
     ],
     "url": "https://github.com/jason-fox/com.here.validate.svrl.text-rules/archive/v2.0.2.zip",
     "cksum": "c3940ba8a4c4d24f331996527cc5ab666b3e05738b0cfe0e0613a1ff5591ab8c"
+  },
+  {
+    "name": "com.here.validate.svrl.text-rules",
+    "description": "Simple rule-based spelling and grammar validation DITA-OT plug-in for text elements within DITA documents.",
+    "keywords": ["validation", "text-lint", "spell-checking", "grammar-checking"],
+    "homepage": "https://jason-fox.github.io/com.here.validate.svrl.text-rules",
+    "vers": "3.0.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "com.here.validate.svrl",
+        "req": ">=3.0.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/com.here.validate.svrl.text-rules/archive/v3.0.0.zip",
+    "cksum": "6bfebafd60033f718c5c7e6389bc166989e516c8b63d09be93c8de43726f6a93"
   }
 ]

--- a/fox.jason.pretty-dita.json
+++ b/fox.jason.pretty-dita.json
@@ -14,5 +14,21 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.pretty-dita/archive/v1.1.0.zip",
     "cksum": "ec39977619bb1c59f99dbedf7aa10ab739b76a6ae55edd292433a45d19c05f0f"
+  },
+  {
+    "name": "fox.jason.pretty-dita",
+    "description": "A DITA prettifier DITA-OT Plug-in which formats DITA XML in an aesthetically pleasing manner.",
+    "keywords": ["pretty-print", "dita", "formatting"],
+    "homepage": "https://jason-fox.github.io/fox.jason.pretty-dita",
+    "vers": "1.2.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.pretty-dita/archive/v1.2.0.zip",
+    "cksum": "4239996840c977890ebc8f791223d74ded4b6a02e09965371376860b9993180d"
   }
 ]

--- a/fox.jason.splash.json
+++ b/fox.jason.splash.json
@@ -14,5 +14,21 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.splash/archive/v1.0.2.zip",
     "cksum": "a20662ae3410dd4bd46e7bde8875e26c2826a7f4e7ad617c10847b8ce1bcffec"
+  },
+  {
+    "name": "fox.jason.splash",
+    "description": "Splash Screen Plug-in for DITA-OT.",
+    "keywords": ["splash-screen", "xkcd", "cats"],
+    "homepage": "https://jason-fox.github.io/fox.jason.splash",
+    "vers": "2.0.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.splash/archive/v2.0.0.zip",
+    "cksum": "4923022afc9703754782a9726ed1c85ca4319b71018c2c2eec7775f3f3b587c5"
   }
 ]


### PR DESCRIPTION
* Remove legacy 2.x support  - set min version to 3.0
* Delete unnecessary templates
* Update plugins to use ANT import.
* Add versioning to plugin files.

Signed-off-by: Jason Fox <jason.fox@fiware.org>