### PR TITLE
Adding ReadTheDocs

### DIFF
--- a/fox.jason.readthedocs.json
+++ b/fox.jason.readthedocs.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "fox.jason.readthedocs",
+    "description": "Plug-in to create a set of output files suitable for a ReadTheDocs documentation project",
+    "keywords": ["readthedocs", "markdown"],
+    "homepage": "https://github.com/jason-fox/fox.jason.readthedocs/blob/master/README.md",
+    "vers": "1.0.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.readthedocs/archive/v1.0.0.zip",
+    "cksum": "fa55a3fc9f803c1ca659e13bb0e23bb84ad0c1f51bb9e214974977ef44a50a93"
+  }
+]

--- a/fox.jason.readthedocs.json
+++ b/fox.jason.readthedocs.json
@@ -3,7 +3,7 @@
     "name": "fox.jason.readthedocs",
     "description": "Plug-in to create a set of output files suitable for a ReadTheDocs documentation project",
     "keywords": ["readthedocs", "markdown"],
-    "homepage": "https://github.com/jason-fox/fox.jason.readthedocs/blob/master/README.md",
+    "homepage": "https://jason-fox.github.io/fox.jason.readthedocs",
     "vers": "1.0.0",
     "license": "Apache-2.0",
     "deps": [

--- a/fox.jason.readthedocs.json
+++ b/fox.jason.readthedocs.json
@@ -10,6 +10,10 @@
       {
         "name": "org.dita.base",
         "req": ">=3.0.0"
+      },
+      {
+        "name": "org.lwdita",
+        "req": ">=2.2.0"
       }
     ],
     "url": "https://github.com/jason-fox/fox.jason.readthedocs/archive/v1.0.0.zip",


### PR DESCRIPTION
This is a DITA-OT Plug-in which creates a set of output files suitable to create a [ReadTheDocs](https://readthedocs.org) Documentation Project. The transform is an extension of the existing DITA-OT markdown plug-in (`org.lwdita`) and creates a well-formatted `mkdocs.yaml` file

### Sample `mkdocs.yaml` File

```yaml
site_name: 'ReadTheDocs Plug-in'

pages:
  -  Home: index.md
  -  'ReadTheDocs':
       -  'Examples': 'topics/examples.md'
       -  'Full list of features': 'topics/features-full.md'
       -  'Basic usage': 'topics/basic-usage.md'

theme: mkdocs
```

Signed-off-by: Jason Fox <jason.fox@fiware.org>

