### PR TITLE
Add audiobook

### DIFF
--- a/fox.jason.audiobook.json
+++ b/fox.jason.audiobook.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "fox.jason.audiobook",
+    "description": "Transforms DITA to speech in the form of an audiobook. It uses freely available Text-to-Speech cloud services to transform SSML files into MP3 audio files or a single m4a audiobook.",
+    "keywords": ["speech-synthesis", "audio-processing", "audiobook", "text-to-speech"],
+    "homepage": "https://jason-fox.github.io/fox.jason.audiobook",
+    "vers": "1.0.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.audiobook/archive/v1.0.0.zip",
+    "cksum": "395408a3dc9c3db2b5c200b8722a13a60898c861633b99e6e250186adffd1370"
+  }
+]

--- a/fox.jason.audiobook.json
+++ b/fox.jason.audiobook.json
@@ -13,6 +13,6 @@
       }
     ],
     "url": "https://github.com/jason-fox/fox.jason.audiobook/archive/v1.0.0.zip",
-    "cksum": "395408a3dc9c3db2b5c200b8722a13a60898c861633b99e6e250186adffd1370"
+    "cksum": "ed1a96639cc007aef96568afe85a3466db54921ef446e929b08e19b18a610060"
   }
 ]


### PR DESCRIPTION
This DITA-OT plug-in transforms DITA to speech in the form of an audiobook. It uses freely available Text-to-Speech cloud services to transform SSML files into MP3 audio files or a single `m4a` audiobook.

### DITA Topic

```xml
<task id="replacecover" xml:lang="en-us">
  <title>Replace the cover of your system.</title>
  <shortdesc>The cover needs to be put back on to reduce problems from dust.</shortdesc>
  <taskbody>
    <steps>
      <step>
        <cmd>Retrieve the computer's cover from its safe place. Put it back on.</cmd>
      </step>
      <step>
        <cmd>Retrieve the screws from the safe place. Put them back in.</cmd>
      </step>
      <step>
        <cmd>Put away your screwdriver before you lose it.</cmd>
      </step>
    </steps>
  </taskbody>
</task>
```

### MP3 Output File

<audio controls>
  <source src="https://jason-fox.github.io/fox.jason.audiobook/replacecover.mp3" type="audio/mpeg">
  <a href="https://jason-fox.github.io/fox.jason.audiobook/replacecover.mp3">
    <img src="https://jason-fox.github.io/fox.jason.audiobook/mp3.png"/>
  </a>
</audio>

## How Has This Been Tested?
A suite of unit tests added to repo

## Type of Changes
- New feature - New plug-in

---

Signed-off-by: Jason Fox <jason.fox@fiware.org>