### PR TITLE
Add Swagger plugin, Postman Plugin, Pandoc plugin and its Passthrough dependency plugin

### DIFF
--- a/fox.jason.passthrough.json
+++ b/fox.jason.passthrough.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "fox.jason.passthrough",
+    "description": "Plug-in to enable files to bypass DITA-OT pre-processing",
+    "keywords": ["passthrough"],
+    "homepage": "https://jason-fox.github.io/fox.jason.passthrough",
+    "vers": "1.0.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "org.doctales.xmltask",
+        "req": ">=1.16.1"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.passthrough/archive/v1.0.0.zip",
+    "cksum": "a1284de4dc2554f433466cdc50ac715392030d010d4fc252fa55edfe069fa61d"
+  }
+]

--- a/fox.jason.passthrough.pandoc.json
+++ b/fox.jason.passthrough.pandoc.json
@@ -21,6 +21,6 @@
       }
     ],
     "url": "https://github.com/jason-fox/fox.jason.passthrough.pandoc/archive/v1.1.0.zip",
-    "cksum": "5b83ea8326590e5dbed4910e3d0f49717c6b03818009a67b6d21018058587b9e"
+    "cksum": "8d9b1687de575efb1f5f2b4faba555b531ce22bc10c88e077e4ecb5b84eb602f"
   }
 ]

--- a/fox.jason.passthrough.pandoc.json
+++ b/fox.jason.passthrough.pandoc.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "fox.jason.passthrough.pandoc",
+    "description": "Pandoc Plug-in for extending the available input formats for DITA-OT. Non DITA input sources can be pre-processed to create create valid DITA source.",
+    "keywords": ["pandoc","DocBook","HTML","markdown","MS Word", "docx", "odt", "wiki", "rst", "epub", "latex"],
+    "homepage": "https://jason-fox.github.io/fox.jason.passthrough.pandoc",
+    "vers": "1.0.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "org.doctales.xmltask",
+        "req": ">=1.16.1"
+      },
+      {
+        "name": "fox.jason.passthrough",
+        "req": ">=1.0.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.passthrough.pandoc/archive/v1.0.0.zip",
+    "cksum": "a33ed6643d1d864ffd4ccc719c3bc9b52191732b1e22fb18724a19b3f8f1f432"
+  }
+]

--- a/fox.jason.passthrough.pandoc.json
+++ b/fox.jason.passthrough.pandoc.json
@@ -4,7 +4,7 @@
     "description": "Pandoc Plug-in for extending the available input formats for DITA-OT. Non DITA input sources can be pre-processed to create create valid DITA source.",
     "keywords": ["pandoc","DocBook","HTML","markdown","MS Word", "docx", "odt", "wiki", "rst", "epub", "latex"],
     "homepage": "https://jason-fox.github.io/fox.jason.passthrough.pandoc",
-    "vers": "1.0.0",
+    "vers": "1.1.0",
     "license": "Apache-2.0",
     "deps": [
       {
@@ -20,7 +20,7 @@
         "req": ">=1.0.0"
       }
     ],
-    "url": "https://github.com/jason-fox/fox.jason.passthrough.pandoc/archive/v1.0.0.zip",
-    "cksum": "6269fdf5efaa2a7fc6cbfcc4927bbcba9f21515387c5a97802431486bf43ea62"
+    "url": "https://github.com/jason-fox/fox.jason.passthrough.pandoc/archive/v1.1.0.zip",
+    "cksum": "5b83ea8326590e5dbed4910e3d0f49717c6b03818009a67b6d21018058587b9e"
   }
 ]

--- a/fox.jason.passthrough.pandoc.json
+++ b/fox.jason.passthrough.pandoc.json
@@ -21,6 +21,6 @@
       }
     ],
     "url": "https://github.com/jason-fox/fox.jason.passthrough.pandoc/archive/v1.0.0.zip",
-    "cksum": "a33ed6643d1d864ffd4ccc719c3bc9b52191732b1e22fb18724a19b3f8f1f432"
+    "cksum": "1b91426c49b3c1db1518b302cb87ea61d2eb30178d2fca9ba97f0d8aebaa5998"
   }
 ]

--- a/fox.jason.passthrough.pandoc.json
+++ b/fox.jason.passthrough.pandoc.json
@@ -21,6 +21,6 @@
       }
     ],
     "url": "https://github.com/jason-fox/fox.jason.passthrough.pandoc/archive/v1.0.0.zip",
-    "cksum": "1b91426c49b3c1db1518b302cb87ea61d2eb30178d2fca9ba97f0d8aebaa5998"
+    "cksum": "6269fdf5efaa2a7fc6cbfcc4927bbcba9f21515387c5a97802431486bf43ea62"
   }
 ]

--- a/fox.jason.passthrough.postman.json
+++ b/fox.jason.passthrough.postman.json
@@ -1,0 +1,30 @@
+[
+  {
+    "name": "fox.jason.passthrough.postman",
+    "description": "DITA-OT Plug-in to automatically create REST API documentation from a Postman Collection",
+    "keywords": ["postman", "REST", "auto-generated text"],
+    "homepage": "https://jason-fox.github.io/fox.jason.passthrough.postman",
+    "vers": "1.0.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "org.doctales.xmltask",
+        "req": ">=1.16.1"
+      },
+      {
+        "name": "fox.jason.passthrough",
+        "req": ">=1.0.0"
+      },
+      {
+        "name": "fox.jason.passthrough.pandoc",
+        "req": ">=1.1.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.passthrough.swagger/archive/v1.0.0.zip",
+    "cksum": "b1177a462706427af884c385eeba176c1e69b8313b277c9bee72b0b536f901e7"
+  }
+]

--- a/fox.jason.passthrough.postman.json
+++ b/fox.jason.passthrough.postman.json
@@ -24,7 +24,7 @@
         "req": ">=1.1.0"
       }
     ],
-    "url": "https://github.com/jason-fox/fox.jason.passthrough.swagger/archive/v1.0.0.zip",
+    "url": "https://github.com/jason-fox/fox.jason.passthrough.postman/archive/v1.0.0.zip",
     "cksum": "b1177a462706427af884c385eeba176c1e69b8313b277c9bee72b0b536f901e7"
   }
 ]

--- a/fox.jason.passthrough.swagger.json
+++ b/fox.jason.passthrough.swagger.json
@@ -21,10 +21,10 @@
       },
       {
         "name": "fox.jason.passthrough.pandoc",
-        "req": ">=1.0.0"
+        "req": ">=1.1.0"
       }
     ],
     "url": "https://github.com/jason-fox/fox.jason.passthrough.swagger/archive/v1.0.0.zip",
-    "cksum": "db594c7eefa3947aea520b4cdcf6987b434c171c5d480f03a667f027fef42175"
+    "cksum": "22177754825c75f835077e434845ff608c5d4b88e10cc65cc01ed3ca168d7d9f"
   }
 ]

--- a/fox.jason.passthrough.swagger.json
+++ b/fox.jason.passthrough.swagger.json
@@ -1,0 +1,30 @@
+[
+  {
+    "name": "fox.jason.passthrough.swagger",
+    "description": "DITA-OT Plug-in to automatically create REST API documentation from a Swagger definition",
+    "keywords": ["swagger", "REST", "auto-generated text"],
+    "homepage": "https://jason-fox.github.io/fox.jason.passthrough.swagger",
+    "vers": "1.0.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "org.doctales.xmltask",
+        "req": ">=1.16.1"
+      },
+      {
+        "name": "fox.jason.passthrough",
+        "req": ">=1.0.0"
+      },
+      {
+        "name": "fox.jason.passthrough.pandoc",
+        "req": ">=1.0.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.passthrough.swagger/archive/v1.0.0.zip",
+    "cksum": "db594c7eefa3947aea520b4cdcf6987b434c171c5d480f03a667f027fef42175"
+  }
+]


### PR DESCRIPTION
## Description

### Pandoc Plug-In

**Pandoc** DITA-OT Plug-in for extending the available input file formats for DITA-OT. Non DITA input sources can be pre-processed to create create valid DITA source.

A  DITA-OT Plug-in to extend the available input formats for DITA-OT. Non DITA input sources can be
pre-processed using [Pandoc](https://pandoc.org/) to create create valid DITA source. Files written in multiple input
formats can be directly added to a `*.ditamap` and processed as if they had been written in DITA.

**Pandoc** is a Haskell library for converting from one markup format to another, and a command-line tool that uses this library. It can convert from the following formats:

-   **Markdown:** `commonmark` ([CommonMark](http://commonmark.org) Markdown) ,`gfm`
    ([GitHub-Flavored Markdown](https://help.github.com/articles/github-flavored-markdown/)) ,`markdown`
    ([Pandoc’s Markdown](#pandocs-markdown)) ,`markdown_mmd` ([MultiMarkdown](http://fletcherpenney.net/multimarkdown/))
    ,`markdown_phpextra` ([PHP Markdown Extra](https://michelf.ca/projects/php-markdown/extra/)) ,`markdown_strict`
    (original unextended [Markdown](http://daringfireball.net/projects/markdown/))

-   **Wiki Formats:** `dokuwiki` ([DokuWiki markup](https://www.dokuwiki.org/dokuwiki)) ,`mediawiki`
    ([MediaWiki markup](https://www.mediawiki.org/wiki/Help:Formatting)) ,`muse`
    ([Muse](https://amusewiki.org/library/manual)) ,`tikiwiki`
    ([TikiWiki markup](https://doc.tiki.org/Wiki-Syntax-Text#The_Markup_Language_Wiki-Syntax)) ,`twiki`
    ([TWiki markup](http://twiki.org/cgi-bin/view/TWiki/TextFormattingRules)) ,`vimwiki`
    ([Vimwiki](https://vimwiki.github.io))

-   **Other Formats:** `creole` ([Creole 1.0](http://www.wikicreole.org/wiki/Creole1.0)) ,`docbook`
    ([DocBook](http://docbook.org)) ,`docx` ([Word docx](https://en.wikipedia.org/wiki/Office_Open_XML)) ,`epub`
    ([EPUB](http://idpf.org/epub)) ,`fb2`
    ([FictionBook2](http://www.fictionbook.org/index.php/Eng:XML_Schema_Fictionbook_2.1) e-book) ,`haddock`
    ([Haddock markup](https://www.haskell.org/haddock/doc/html/ch03s08.html)) ,`html` ([HTML](http://www.w3.org/html/))
    ,`ipynb` ([Jupyter notebook](https://nbformat.readthedocs.io/en/latest/)) ,`jats` ([JATS](https://jats.nlm.nih.gov)
    XML) ,`json` (JSON version of native AST) ,`latex` ([LaTeX](http://latex-project.org)) ,`man`
    ([roff man](http://man7.org/linux/man-pages/man7/groff_man.7.html)) ,`native` (native Haskell) ,`odt`
    ([ODT](http://en.wikipedia.org/wiki/OpenDocument)) ,`opml` ([OPML](http://dev.opml.org/spec2.html)) ,`org`
    ([Emacs Org mode](http://orgmode.org)) ,`rst`
    ([reStructuredText](http://docutils.sourceforge.net/docs/ref/rst/introduction.html)) ,`t2t`
    ([txt2tags](http://txt2tags.org)) ,`textile` ([Textile](http://redcloth.org/textile))

This plug-in contains a Lua template which extends the output formats supported by **Pandoc** to include DITA. The output consists of a single DITA topic for each input file added to the ditamap.

---

### Swagger Plug-In

The **Swagger** DITA-OT Plug-in to used to auto-create valid DITA-based REST API documentation. The documentation can be generated directly from a Swagger files and processed as if they had been written in DITA.

**Swagger** is an open-source software framework backed by a large ecosystem of tools that helps developers design, build, document, and consume RESTful Web services. While most users identify Swagger by the Swagger UI tool, the Swagger toolset includes support for automated documentation, code generation, and test-case generation.

**Swagger2Markup** converts a Swagger JSON or YAML file into one or more AsciiDoc or GitHub Flavored Markdown documents which can be combined with hand-written documentation. The Swagger source file can be located locally or remotely via HTTP. Swagger2Markup supports the Swagger 1.2 and 2.0 specification. Internally it uses the official swagger-parser and my markup-document-builder.

This plugin processes the Swagger file to Pandoc markdown, and the converts the markdown to DITA using the Pandoc DITA-OT Plugin

---

### Postman Plug-In

The **Postman** DITA-OT Plug-in used to auto-create valid DITA-based REST API documentation. The documentation can be generated directly from a **Postman Collection** file and processed as if it had been written in DITA.

**Postman** is a software development tool which a developer can use to build, publish, document, design, monitor, test and debug their REST APIs.

This plugin processes a Postman collection to Pandoc markdown, and the converts the markdown to DITA using the Pandoc DITA-OT Plugin allowing the generation of PDF API documentation.


Signed-off-by: Jason Fox <jason.fox@fiware.org>
