### PR TITLE
Making the Prism-JS plugin more flexible

### DIFF
--- a/fox.jason.extend.css.json
+++ b/fox.jason.extend.css.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "fox.jason.extend.css",
+    "description": "Extension to allow additional plug-ins to add an extra CSS stylesheet to HTML pages.",
+    "keywords": ["html", "css"],
+    "homepage": "https://jason-fox.github.io/fox.jason.extend.css",
+    "vers": "1.0.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.1.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.extend.css/archive/v1.0.0.zip",
+    "cksum": "992faf0e3a20d3ec9c2b064f07958bb6e3fe3dd97ca50a2744636971d00f30f0"
+  }
+]

--- a/fox.jason.passthrough.json
+++ b/fox.jason.passthrough.json
@@ -38,5 +38,25 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.passthrough/archive/v2.1.0.zip",
     "cksum": "ec20099b56f2278deee4cf6494372778aeb234d7e3171753b1476faca7f8d7f0"
+  },
+  {
+    "name": "fox.jason.passthrough",
+    "description": "Plug-in to enable files to bypass DITA-OT pre-processing",
+    "keywords": ["passthrough"],
+    "homepage": "https://jason-fox.github.io/fox.jason.passthrough",
+    "vers": "2.2.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "org.doctales.xmltask",
+        "req": ">=1.16.1"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.passthrough/archive/v2.2.0.zip",
+    "cksum": "99061e1cb7d98d53e358ec12f5b996248b8d8a21f69a3dc375b8ef9d48494014"
   }
 ]

--- a/fox.jason.passthrough.json
+++ b/fox.jason.passthrough.json
@@ -18,5 +18,25 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.passthrough/archive/v1.0.0.zip",
     "cksum": "a1284de4dc2554f433466cdc50ac715392030d010d4fc252fa55edfe069fa61d"
+  },
+  {
+    "name": "fox.jason.passthrough",
+    "description": "Plug-in to enable files to bypass DITA-OT pre-processing",
+    "keywords": ["passthrough"],
+    "homepage": "https://jason-fox.github.io/fox.jason.passthrough",
+    "vers": "2.1.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "org.doctales.xmltask",
+        "req": ">=1.16.1"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.passthrough/archive/v2.1.0.zip",
+    "cksum": "ec20099b56f2278deee4cf6494372778aeb234d7e3171753b1476faca7f8d7f0"
   }
 ]

--- a/fox.jason.passthrough.pandoc.json
+++ b/fox.jason.passthrough.pandoc.json
@@ -46,5 +46,29 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.passthrough.pandoc/archive/v1.2.0.zip",
     "cksum": "e6dd1259fea08b20edd9035889137cfe665cbd8a07ebf1203f0854d251a202aa"
+  },
+  {
+    "name": "fox.jason.passthrough.pandoc",
+    "description": "Pandoc Plug-in for extending the available input formats for DITA-OT. Non DITA input sources can be pre-processed to create create valid DITA source.",
+    "keywords": ["pandoc","DocBook","HTML","markdown","MS Word", "docx", "odt", "wiki", "rst", "epub", "latex"],
+    "homepage": "https://jason-fox.github.io/fox.jason.passthrough.pandoc",
+    "vers": "1.2.1",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "org.doctales.xmltask",
+        "req": ">=1.16.1"
+      },
+      {
+        "name": "fox.jason.passthrough",
+        "req": ">=2.2.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.passthrough.pandoc/archive/v1.2.1.zip",
+    "cksum": "02120ed1d516b14a4f1c86afc28ffcbb20e97f7488c845c2b81e3c3b2368aa22"
   }
 ]

--- a/fox.jason.passthrough.pandoc.json
+++ b/fox.jason.passthrough.pandoc.json
@@ -22,5 +22,29 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.passthrough.pandoc/archive/v1.1.0.zip",
     "cksum": "8d9b1687de575efb1f5f2b4faba555b531ce22bc10c88e077e4ecb5b84eb602f"
+  },
+  {
+    "name": "fox.jason.passthrough.pandoc",
+    "description": "Pandoc Plug-in for extending the available input formats for DITA-OT. Non DITA input sources can be pre-processed to create create valid DITA source.",
+    "keywords": ["pandoc","DocBook","HTML","markdown","MS Word", "docx", "odt", "wiki", "rst", "epub", "latex"],
+    "homepage": "https://jason-fox.github.io/fox.jason.passthrough.pandoc",
+    "vers": "1.2.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "org.doctales.xmltask",
+        "req": ">=1.16.1"
+      },
+      {
+        "name": "fox.jason.passthrough",
+        "req": ">=2.1.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.passthrough.pandoc/archive/v1.2.0.zip",
+    "cksum": "e6dd1259fea08b20edd9035889137cfe665cbd8a07ebf1203f0854d251a202aa"
   }
 ]

--- a/fox.jason.passthrough.postman.json
+++ b/fox.jason.passthrough.postman.json
@@ -62,6 +62,42 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.passthrough.postman/archive/v1.1.0.zip",
     "cksum": "af841454a6b7b885122c290c60e876d606a0bf3c67de7683912d1c80d59f00f5"
+  },
+  {
+    "name": "fox.jason.passthrough.postman",
+    "description": "DITA-OT Plug-in to automatically create REST API documentation from a Postman Collection",
+    "keywords": ["postman", "REST", "auto-generated text"],
+    "homepage": "https://jason-fox.github.io/fox.jason.passthrough.postman",
+    "vers": "1.1.1",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "org.doctales.xmltask",
+        "req": ">=1.16.1"
+      },
+      {
+        "name": "fox.jason.extend.css",
+        "req": ">=1.0.0"
+      },
+      {
+        "name": "fox.jason.passthrough",
+        "req": ">=2.2.0"
+      },
+      {
+        "name": "fox.jason.passthrough.pandoc",
+        "req": ">=1.2.1"
+      },
+      {
+        "name": "fox.jason.passthrough.swagger",
+        "req": ">=1.1.1"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.passthrough.postman/archive/v1.1.1.zip",
+    "cksum": "bbbd59d05c958c832f4c2058a5e3bdabeb6b7f296b73cf4c2de740bc0afa0bc6"
   }
 
 ]

--- a/fox.jason.passthrough.postman.json
+++ b/fox.jason.passthrough.postman.json
@@ -26,5 +26,42 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.passthrough.postman/archive/v1.0.0.zip",
     "cksum": "b1177a462706427af884c385eeba176c1e69b8313b277c9bee72b0b536f901e7"
+  },
+  {
+    "name": "fox.jason.passthrough.postman",
+    "description": "DITA-OT Plug-in to automatically create REST API documentation from a Postman Collection",
+    "keywords": ["postman", "REST", "auto-generated text"],
+    "homepage": "https://jason-fox.github.io/fox.jason.passthrough.postman",
+    "vers": "1.1.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "org.doctales.xmltask",
+        "req": ">=1.16.1"
+      },
+      {
+        "name": "fox.jason.extend.css",
+        "req": ">=1.0.0"
+      },
+      {
+        "name": "fox.jason.passthrough",
+        "req": ">=2.1.0"
+      },
+      {
+        "name": "fox.jason.passthrough.pandoc",
+        "req": ">=1.2.0"
+      },
+      {
+        "name": "fox.jason.passthrough.swagger",
+        "req": ">=1.1.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.passthrough.postman/archive/v1.1.0.zip",
+    "cksum": "af841454a6b7b885122c290c60e876d606a0bf3c67de7683912d1c80d59f00f5"
   }
+
 ]

--- a/fox.jason.passthrough.swagger.json
+++ b/fox.jason.passthrough.swagger.json
@@ -26,5 +26,37 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.passthrough.swagger/archive/v1.0.0.zip",
     "cksum": "22177754825c75f835077e434845ff608c5d4b88e10cc65cc01ed3ca168d7d9f"
+  },
+  {
+    "name": "fox.jason.passthrough.swagger",
+    "description": "DITA-OT Plug-in to automatically create REST API documentation from a Swagger definition",
+    "keywords": ["swagger", "REST", "auto-generated text"],
+    "homepage": "https://jason-fox.github.io/fox.jason.passthrough.swagger",
+    "vers": "1.1.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "org.doctales.xmltask",
+        "req": ">=1.16.1"
+      },
+      {
+        "name": "fox.jason.extend.css",
+        "req": ">=1.0.0"
+      },
+      {
+        "name": "fox.jason.passthrough",
+        "req": ">=2.1.0"
+      },
+      {
+        "name": "fox.jason.passthrough.pandoc",
+        "req": ">=1.2.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.passthrough.swagger/archive/v1.1.0.zip",
+    "cksum": "88e8f17bf37526f80330e7155a94a7fc2f2c6bdd6d6837e90d27833d6ddea8ec"
   }
 ]

--- a/fox.jason.passthrough.swagger.json
+++ b/fox.jason.passthrough.swagger.json
@@ -89,6 +89,6 @@
       }
     ],
     "url": "https://github.com/jason-fox/fox.jason.passthrough.swagger/archive/v1.1.1.zip",
-    "cksum": "bbbd59d05c958c832f4c2058a5e3bdabeb6b7f296b73cf4c2de740bc0afa0bc6"
+    "cksum": "2b3b36961a4db9c79447dd1e2059ba4f2e03990ad63875fe43d53e522e0f2488"
   }
 ]

--- a/fox.jason.passthrough.swagger.json
+++ b/fox.jason.passthrough.swagger.json
@@ -58,5 +58,37 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.passthrough.swagger/archive/v1.1.0.zip",
     "cksum": "88e8f17bf37526f80330e7155a94a7fc2f2c6bdd6d6837e90d27833d6ddea8ec"
+  },
+  {
+    "name": "fox.jason.passthrough.swagger",
+    "description": "DITA-OT Plug-in to automatically create REST API documentation from a Swagger definition",
+    "keywords": ["swagger", "REST", "auto-generated text"],
+    "homepage": "https://jason-fox.github.io/fox.jason.passthrough.swagger",
+    "vers": "1.1.1",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "org.doctales.xmltask",
+        "req": ">=1.16.1"
+      },
+      {
+        "name": "fox.jason.extend.css",
+        "req": ">=1.0.0"
+      },
+      {
+        "name": "fox.jason.passthrough",
+        "req": ">=2.2.0"
+      },
+      {
+        "name": "fox.jason.passthrough.pandoc",
+        "req": ">=1.2.1"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.passthrough.swagger/archive/v1.1.1.zip",
+    "cksum": "bbbd59d05c958c832f4c2058a5e3bdabeb6b7f296b73cf4c2de740bc0afa0bc6"
   }
 ]

--- a/fox.jason.prismjs.dark-theme.json
+++ b/fox.jason.prismjs.dark-theme.json
@@ -10,7 +10,15 @@
       {
         "name": "org.dita.base",
         "req": ">=3.1.0"
-      }
+      },
+      {
+        "name": "fox.jason.extend.css",
+        "req": ">=1.0.0"
+      },
+      {
+        "name": "fox.jason.prismjs",
+        "req": ">=2.1.0"
+      },
     ],
     "url": "https://github.com/jason-fox/fox.jason.prismjs.dark-theme/archive/v1.0.0.zip",
     "cksum": "1d1e68299db986aa91e41642126c55648aaaef7c39218fac3ebee74fc54626a0"

--- a/fox.jason.prismjs.dark-theme.json
+++ b/fox.jason.prismjs.dark-theme.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "fox.jason.prismjs.dark-theme",
+    "description": "Extension of the DITA-OT Prism-JS plug-in to amend the look-and-feel of highlighted code. Offers the standard Dark Theme from Prism-JS.",
+    "keywords": ["prismjs", "code-highlighter", "syntax-highlighting", "css"],
+    "homepage": "https://jason-fox.github.io/fox.jason.prismjs.dark-theme",
+    "vers": "1.0.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.1.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.prismjs.dark-theme/archive/v1.0.0.zip",
+    "cksum": "1d1e68299db986aa91e41642126c55648aaaef7c39218fac3ebee74fc54626a0"
+  }
+]

--- a/fox.jason.prismjs.dark-theme.json
+++ b/fox.jason.prismjs.dark-theme.json
@@ -18,7 +18,7 @@
       {
         "name": "fox.jason.prismjs",
         "req": ">=2.1.0"
-      },
+      }
     ],
     "url": "https://github.com/jason-fox/fox.jason.prismjs.dark-theme/archive/v1.0.0.zip",
     "cksum": "1d1e68299db986aa91e41642126c55648aaaef7c39218fac3ebee74fc54626a0"

--- a/fox.jason.prismjs.json
+++ b/fox.jason.prismjs.json
@@ -66,5 +66,29 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.prismjs/archive/v2.0.0.zip",
     "cksum": "c5ff76e57aab47885fed399a7911350202dfc1eaf9c7080f0eb11befe92e7ee0"
+  },
+  {
+    "name": "fox.jason.prismjs",
+    "description": "An integration of Prism-JS into the DITA Open Toolkit engine, enabling static HTML and PDF syntax highlighting.",
+    "keywords": ["prismjs", "code-highlighter", "syntax-highlighting"],
+    "homepage": "https://jason-fox.github.io/fox.jason.prismjs",
+    "vers": "2.1.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.1.0"
+      },
+      {
+        "name": "org.doctales.xmltask",
+        "req": ">=1.16.1"
+      },
+      {
+        "name": "fox.jason.extend.css",
+        "req": ">=1.0.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.prismjs/archive/v2.1.0.zip",
+    "cksum": "db7e29de9a2d4ee62b43e5c28ea76302cf3548343793f02bf32074ef86f28ee8"
   }
 ]


### PR DESCRIPTION

* `fox.jason.prismjs` **2.1.0**
    - Dynamically loading Prism.js languages to support 80+ languages
    - Allowing CSS to be overridden by an extension plugin (see below)
    - Allowing PDF look-and-feel to be overridden by an extension plugin (see below)
    - Amending file selection to include all processed Dita files
    - Ensuring that class="language-*" is available on all processed blocks.
    - Additional maintenance and fixes
    - Update base Prism-JS files to 1.17.1
    - Add dependency on fox.jason.extend.css (see below)

---

* `fox.jason.prismjs.dark-theme` **1.0.0**

Extension of the DITA-OT Prism-JS plug-in to amend the look-and-feel of highlighted code. Offers the standard Dark Theme from [Prism-JS](https://prismjs.com/). Sample override of standard look-and-feel

![Screenshot 2019-08-29 at 20 28 23](https://user-images.githubusercontent.com/3439249/63966456-9deff080-ca9b-11e9-9bca-472ab9018fcb.png)

---
* `fox.jason.extend.css` **1.0.0**

DITA-OT Plug-in to extend HTML processing and allow additional plug-ins to add an extra CSS stylesheet to the `<header>` of each HTML page.


Signed-off-by: Jason Fox jason.fox@fiware.org