### PR TITLE
Add tidy-xml macro

### DIFF
--- a/fox.jason.unit-test.json
+++ b/fox.jason.unit-test.json
@@ -29,6 +29,6 @@
       }
     ],
     "url": "https://github.com/jason-fox/fox.jason.unit-test/archive/v1.0.7.zip",
-    "cksum": "dfa68d7db4d643a1f2a8542054f9ce755bbcb50c2bfd7d4d18f1730d96e10686"
+    "cksum": "c3e7311a8e05257053ec214f2aad30fd3e7def80ad03d5f7efa2585229c483c1"
   }
 ]

--- a/fox.jason.unit-test.json
+++ b/fox.jason.unit-test.json
@@ -14,5 +14,21 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.unit-test/archive/v1.0.5.zip",
     "cksum": "dfa68d7db4d643a1f2a8542054f9ce755bbcb50c2bfd7d4d18f1730d96e10686"
+  },
+  {
+    "name": "fox.jason.unit-test",
+    "description": "Unit Testing and Code Coverage Framework for DITA-OT.",
+    "keywords": ["unit-testing", "code-coverage", "profiling"],
+    "homepage": "https://jason-fox.github.io/fox.jason.unit-test",
+    "vers": "1.0.7",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=2.3.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.unit-test/archive/v1.0.7.zip",
+    "cksum": "dfa68d7db4d643a1f2a8542054f9ce755bbcb50c2bfd7d4d18f1730d96e10686"
   }
 ]


### PR DESCRIPTION
Add release 1.0.7 of the unit test plug-in

- Add `tidy-xml` macro
- Additional `taskname` attributes for debugging
- Coveralls support for JDK 10+
- Documentation updates