### PR TITLE
Bugfix release for passthrough 2.2.1

### DIFF
--- a/fox.jason.passthrough.json
+++ b/fox.jason.passthrough.json
@@ -58,5 +58,25 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.passthrough/archive/v2.2.0.zip",
     "cksum": "99061e1cb7d98d53e358ec12f5b996248b8d8a21f69a3dc375b8ef9d48494014"
+  },
+  {
+    "name": "fox.jason.passthrough",
+    "description": "Plug-in to enable files to bypass DITA-OT pre-processing",
+    "keywords": ["passthrough"],
+    "homepage": "https://jason-fox.github.io/fox.jason.passthrough",
+    "vers": "2.2.1",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "org.doctales.xmltask",
+        "req": ">=1.16.1"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.passthrough/archive/v2.2.1.zip",
+    "cksum": "34de8279d9ae7ae883c09ad18c5ded544519e87e58e929a384892f3b291e89c7"
   }
 ]


### PR DESCRIPTION
Additional release of base passthrough plugin. Incompatibility found with the pretty-dita transform.