### PR TITLE
Initial release of JavaDoc Plugin

### DIFF
--- a/fox.jason.passthrough.javadoc.json
+++ b/fox.jason.passthrough.javadoc.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "fox.jason.passthrough.javadoc",
+    "description": "DITA-OT Plug-in to automatically create API documentation extracted from comments within Java source code.",
+    "keywords": ["javadoc", "java", "auto-generated text"],
+    "homepage": "https://jason-fox.github.io/fox.jason.passthrough.javadoc",
+    "vers": "1.0.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.3.0"
+      },
+      {
+        "name": "org.doctales.xmltask",
+        "req": ">=1.16.1"
+      },
+      {
+        "name": "fox.jason.passthrough",
+        "req": ">=2.2.1"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.passthrough.javadoc/archive/v1.0.0.zip",
+    "cksum": "2a78574eb5ca7ebde78a7e4d8567b2bf8df528c3428df7489341133f76dc1eac"
+  }
+]


### PR DESCRIPTION
* `fox.jason.passthrough.javadoc` **1.0.0**
    - Create XSLT transforms for JavaDoc XML => DITA processing
    - Add unit tests and code coverage
    - Add documentation

![](https://jason-fox.github.io/fox.jason.passthrough.javadoc/javadoc-output.png)