### PR TITLE
Update released versions to use Java-based plugins.

### DIFF
--- a/fox.jason.audiobook.json
+++ b/fox.jason.audiobook.json
@@ -46,5 +46,21 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.audiobook/archive/v1.2.0.zip",
     "cksum": "88b9c30fead4995049462364edf5d4b4b3fd29eb6cf9a23d599d16aaaa288a39"
+  },
+  {
+    "name": "fox.jason.audiobook",
+    "description": "Transforms DITA to speech in the form of an audiobook. It uses freely available Text-to-Speech cloud services to transform SSML files into MP3 audio files or a single m4a audiobook.",
+    "keywords": ["speech-synthesis", "audio-processing", "audiobook", "text-to-speech"],
+    "homepage": "https://jason-fox.github.io/fox.jason.audiobook",
+    "vers": "1.3.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.audiobook/archive/v1.3.0.zip",
+    "cksum": "c94350783c1d165b175aa950cd4c6678b117b3d6b84a02309fb68361f3b58475"
   }
 ]

--- a/fox.jason.extend.css.json
+++ b/fox.jason.extend.css.json
@@ -14,5 +14,21 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.extend.css/archive/v1.0.0.zip",
     "cksum": "992faf0e3a20d3ec9c2b064f07958bb6e3fe3dd97ca50a2744636971d00f30f0"
+  },
+  {
+    "name": "fox.jason.extend.css",
+    "description": "Extension to allow additional plug-ins to add an extra CSS stylesheet to HTML pages.",
+    "keywords": ["html", "css"],
+    "homepage": "https://jason-fox.github.io/fox.jason.extend.css",
+    "vers": "1.0.1",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.1.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.extend.css/archive/v1.0.1.zip",
+    "cksum": "c9260266c7ee6e46d178499ed9039e4a14a50ac37b161a44e06c01e7bbf099fe"
   }
 ]

--- a/fox.jason.passthrough.javadoc.json
+++ b/fox.jason.passthrough.javadoc.json
@@ -22,5 +22,29 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.passthrough.javadoc/archive/v1.0.0.zip",
     "cksum": "2a78574eb5ca7ebde78a7e4d8567b2bf8df528c3428df7489341133f76dc1eac"
+  },
+  {
+    "name": "fox.jason.passthrough.javadoc",
+    "description": "DITA-OT Plug-in to automatically create API documentation extracted from comments within Java source code.",
+    "keywords": ["javadoc", "java", "auto-generated text"],
+    "homepage": "https://jason-fox.github.io/fox.jason.passthrough.javadoc",
+    "vers": "1.0.1",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.3.0"
+      },
+      {
+        "name": "org.doctales.xmltask",
+        "req": ">=1.16.1"
+      },
+      {
+        "name": "fox.jason.passthrough",
+        "req": ">=3.0.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.passthrough.javadoc/archive/v1.0.1.zip",
+    "cksum": "5119d1b16720de95ee0809a204b2d7794d37696d36a1648465d181e82b8eb663"
   }
 ]

--- a/fox.jason.passthrough.json
+++ b/fox.jason.passthrough.json
@@ -78,5 +78,25 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.passthrough/archive/v2.2.1.zip",
     "cksum": "34de8279d9ae7ae883c09ad18c5ded544519e87e58e929a384892f3b291e89c7"
+  },
+  {
+    "name": "fox.jason.passthrough",
+    "description": "Plug-in to enable files to bypass DITA-OT pre-processing",
+    "keywords": ["passthrough"],
+    "homepage": "https://jason-fox.github.io/fox.jason.passthrough",
+    "vers": "3.0.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "org.doctales.xmltask",
+        "req": ">=1.16.1"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.passthrough/archive/v3.0.0.zip",
+    "cksum": "2783c2bb3231b23a999de30d3126ff2ab396d3f30ab79b2295a66d241280e973"
   }
 ]

--- a/fox.jason.passthrough.pandoc.json
+++ b/fox.jason.passthrough.pandoc.json
@@ -70,5 +70,29 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.passthrough.pandoc/archive/v1.2.1.zip",
     "cksum": "02120ed1d516b14a4f1c86afc28ffcbb20e97f7488c845c2b81e3c3b2368aa22"
+  },
+  {
+    "name": "fox.jason.passthrough.pandoc",
+    "description": "Pandoc Plug-in for extending the available input formats for DITA-OT. Non DITA input sources can be pre-processed to create create valid DITA source.",
+    "keywords": ["pandoc","DocBook","HTML","markdown","MS Word", "docx", "odt", "wiki", "rst", "epub", "latex"],
+    "homepage": "https://jason-fox.github.io/fox.jason.passthrough.pandoc",
+    "vers": "1.3.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "org.doctales.xmltask",
+        "req": ">=1.16.1"
+      },
+      {
+        "name": "fox.jason.passthrough",
+        "req": ">=3.0.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.passthrough.pandoc/archive/v1.3.0.zip",
+    "cksum": "16af99a21eef96de195377225f2b12425f899be5f1efaece033eca62ebbbc395"
   }
 ]

--- a/fox.jason.passthrough.postman.json
+++ b/fox.jason.passthrough.postman.json
@@ -98,6 +98,42 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.passthrough.postman/archive/v1.1.1.zip",
     "cksum": "bbbd59d05c958c832f4c2058a5e3bdabeb6b7f296b73cf4c2de740bc0afa0bc6"
+  },
+  {
+    "name": "fox.jason.passthrough.postman",
+    "description": "DITA-OT Plug-in to automatically create REST API documentation from a Postman Collection",
+    "keywords": ["postman", "REST", "auto-generated text"],
+    "homepage": "https://jason-fox.github.io/fox.jason.passthrough.postman",
+    "vers": "1.2.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "org.doctales.xmltask",
+        "req": ">=1.16.1"
+      },
+      {
+        "name": "fox.jason.extend.css",
+        "req": ">=1.0.1"
+      },
+      {
+        "name": "fox.jason.passthrough",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "fox.jason.passthrough.pandoc",
+        "req": ">=1.3.0"
+      },
+      {
+        "name": "fox.jason.passthrough.swagger",
+        "req": ">=1.2.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.passthrough.postman/archive/v1.2.0.zip",
+    "cksum": "a6f788a7ae00ed396f7747451247d01d52825c4d014a634612fa739b8918be76"
   }
 
 ]

--- a/fox.jason.passthrough.swagger.json
+++ b/fox.jason.passthrough.swagger.json
@@ -90,5 +90,37 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.passthrough.swagger/archive/v1.1.1.zip",
     "cksum": "2b3b36961a4db9c79447dd1e2059ba4f2e03990ad63875fe43d53e522e0f2488"
+  },
+  {
+    "name": "fox.jason.passthrough.swagger",
+    "description": "DITA-OT Plug-in to automatically create REST API documentation from a Swagger definition",
+    "keywords": ["swagger", "REST", "auto-generated text"],
+    "homepage": "https://jason-fox.github.io/fox.jason.passthrough.swagger",
+    "vers": "1.2.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "org.doctales.xmltask",
+        "req": ">=1.16.1"
+      },
+      {
+        "name": "fox.jason.extend.css",
+        "req": ">=1.0.1"
+      },
+      {
+        "name": "fox.jason.passthrough",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "fox.jason.passthrough.pandoc",
+        "req": ">=1.3.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.passthrough.swagger/archive/v1.2.0.zip",
+    "cksum": "7daa42f6ae909b2b1a675f37a678e6693015d3d382e96a01bc9082e9262e46cc"
   }
 ]

--- a/fox.jason.pretty-dita.json
+++ b/fox.jason.pretty-dita.json
@@ -46,5 +46,21 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.pretty-dita/archive/v1.3.0.zip",
     "cksum": "4614a8d87f978898a648541138f5517d1b462ebd6cf241770f7fa442e166113d"
+  },
+  {
+    "name": "fox.jason.pretty-dita",
+    "description": "A DITA prettifier DITA-OT Plug-in which formats DITA XML in an aesthetically pleasing manner.",
+    "keywords": ["pretty-print", "dita", "formatting"],
+    "homepage": "https://jason-fox.github.io/fox.jason.pretty-dita",
+    "vers": "1.4.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.pretty-dita/archive/v1.4.0.zip",
+    "cksum": "268e0f8ed9e72b9afd67dd74d44cf3743a8c095c607e1963444ec038c5abb253"
   }
 ]

--- a/fox.jason.prismjs.dark-theme.json
+++ b/fox.jason.prismjs.dark-theme.json
@@ -22,5 +22,29 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.prismjs.dark-theme/archive/v1.0.0.zip",
     "cksum": "1d1e68299db986aa91e41642126c55648aaaef7c39218fac3ebee74fc54626a0"
+  },
+  {
+    "name": "fox.jason.prismjs.dark-theme",
+    "description": "Extension of the DITA-OT Prism-JS plug-in to amend the look-and-feel of highlighted code. Offers the standard Dark Theme from Prism-JS.",
+    "keywords": ["prismjs", "code-highlighter", "syntax-highlighting", "css"],
+    "homepage": "https://jason-fox.github.io/fox.jason.prismjs.dark-theme",
+    "vers": "1.0.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.1.0"
+      },
+      {
+        "name": "fox.jason.extend.css",
+        "req": ">=1.0.1"
+      },
+      {
+        "name": "fox.jason.prismjs",
+        "req": ">=3.0.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.prismjs.dark-theme/archive/v1.0.1.zip",
+    "cksum": "befe437159c1762c0dd36838fa7f8c8d5e8bb468f8864caf3ce9e6e5ed7acd87"
   }
 ]

--- a/fox.jason.prismjs.json
+++ b/fox.jason.prismjs.json
@@ -114,5 +114,29 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.prismjs/archive/v2.2.0.zip",
     "cksum": "721da4d2059d2f1839a16f9f048499cdb8d84c7a1d4a53d3a15779a1f8b3623a"
+  },
+  {
+    "name": "fox.jason.prismjs",
+    "description": "An integration of Prism-JS into the DITA Open Toolkit engine, enabling static HTML and PDF syntax highlighting.",
+    "keywords": ["prismjs", "code-highlighter", "syntax-highlighting"],
+    "homepage": "https://jason-fox.github.io/fox.jason.prismjs",
+    "vers": "3.0.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.1.0"
+      },
+      {
+        "name": "org.doctales.xmltask",
+        "req": ">=1.16.1"
+      },
+      {
+        "name": "fox.jason.extend.css",
+        "req": ">=1.0.1"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.prismjs/archive/v3.0.0.zip",
+    "cksum": "1715bd9534ff190f14c10bdf13024af27a7f0ad115acf2b2b1cf6d848a8f5d52"
   }
 ]

--- a/fox.jason.readthedocs.json
+++ b/fox.jason.readthedocs.json
@@ -58,5 +58,25 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.readthedocs/archive/v1.2.0.zip",
     "cksum": "8f938238dd6e8122159bf4d5f5bdc9d63bd034a3323187bc8b64b6a5471da468"
+  },
+  {
+    "name": "fox.jason.readthedocs",
+    "description": "Plug-in to create a set of output files suitable for a ReadTheDocs documentation project",
+    "keywords": ["readthedocs", "markdown", "mkdocs"],
+    "homepage": "https://jason-fox.github.io/fox.jason.readthedocs",
+    "vers": "1.3.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "org.lwdita",
+        "req": ">=2.2.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.readthedocs/archive/v1.3.0.zip",
+    "cksum": "468a78d43b8885a252fcb65c4150153100266d6fdbb44a6e218e6ef560442e69"
   }
 ]

--- a/fox.jason.splash.json
+++ b/fox.jason.splash.json
@@ -46,5 +46,21 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.splash/archive/v2.1.0.zip",
     "cksum": "661e051cf0520814bdf79be8a27a29fde149b22f63dc9036a60d273e711ad13d"
+  },
+  {
+    "name": "fox.jason.splash",
+    "description": "Splash Screen Plug-in for DITA-OT.",
+    "keywords": ["splash-screen", "xkcd", "cats"],
+    "homepage": "https://jason-fox.github.io/fox.jason.splash",
+    "vers": "2.2.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.splash/archive/v2.2.0.zip",
+    "cksum": "185cbe02ced86b7a2943cf0096d6f233aff491df28a89dc0213aea6b63a68a7e"
   }
 ]

--- a/fox.jason.translate.xliff.json
+++ b/fox.jason.translate.xliff.json
@@ -34,5 +34,25 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.translate.xliff/archive/v2.0.0.zip",
     "cksum": "f13f4a2cdc29b564946e1c35287d3b0231fb130649242a75d2d73ecb36b7a5e8"
+  },
+  {
+    "name": "fox.jason.translate.xliff",
+    "description": "Creates XLIFF from DITA, auto-translates and re-merges XLIFF files, generating translated documentation in a targeted foreign language.",
+    "keywords": ["xliff", "language-translation"],
+    "homepage": "https://jason-fox.github.io/fox.jason.translate.xliff",
+    "vers": "2.1.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "org.doctales.xmltask",
+        "req": ">=1.16.1"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.translate.xliff/archive/v2.1.0.zip",
+    "cksum": "4c1705a7e43adf60fb0ca48ca3ce0725adeebd7ad05ad824c43fecd829a8fa5c"
   }
 ]

--- a/fox.jason.unit-test.json
+++ b/fox.jason.unit-test.json
@@ -30,5 +30,21 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.unit-test/archive/v1.0.7.zip",
     "cksum": "c3e7311a8e05257053ec214f2aad30fd3e7def80ad03d5f7efa2585229c483c1"
+  },
+  {
+    "name": "fox.jason.unit-test",
+    "description": "Unit Testing and Code Coverage Framework for DITA-OT.",
+    "keywords": ["unit-testing", "code-coverage", "profiling"],
+    "homepage": "https://jason-fox.github.io/fox.jason.unit-test",
+    "vers": "2.0.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.unit-test/archive/v2.0.0.zip",
+    "cksum": "f94633f1617cd572e4dcc6a5d32e68d887072af96ff49d629bc87a25d06ca631"
   }
 ]


### PR DESCRIPTION
Due to the deprecation and removal of the Nashorn Engine in JDK11-14 [JEP 335](https://openjdk.java.net/jeps/335) any plug-in using `<script>` or `<scriptdef>` ANT tasks will start throwing warnings with Java 11 onwards and above.  From Java 15 onwards, these plugins will no longer work.

This PR references new releases of affected plug-ins which are now purely Java-based. The exception is the `pretty-dita` plug-in which relies remains JavaScript-based, but will use Node.js.

I also took the opportunity to make a patch release of other plugins to remove `src` and `test` folders for release to minimize the footprint when installing.

- fox.jason.audiobook v1.3.0
c94350783c1d165b175aa950cd4c6678b117b3d6b84a02309fb68361f3b58475  v1.3.0.zip

- fox.jason.passthrough v3.0.0
2783c2bb3231b23a999de30d3126ff2ab396d3f30ab79b2295a66d241280e973  v3.0.0.zip

- fox.jason.passthrough.javadoc v1.0.1
5119d1b16720de95ee0809a204b2d7794d37696d36a1648465d181e82b8eb663  v1.0.1.zip

- fox.jason.passthrough.pandoc v1.3.0
16af99a21eef96de195377225f2b12425f899be5f1efaece033eca62ebbbc395  v1.3.0.zip

- fox.jason.passthrough.postman v1.2.0
a6f788a7ae00ed396f7747451247d01d52825c4d014a634612fa739b8918be76  v1.2.0.zip

- fox.jason.passthrough.swagger v1.2.0
7daa42f6ae909b2b1a675f37a678e6693015d3d382e96a01bc9082e9262e46cc  v1.2.0.zip

- fox.jason.pretty-dita v1.4.0
268e0f8ed9e72b9afd67dd74d44cf3743a8c095c607e1963444ec038c5abb253  v1.4.0.zip

- fox.jason.prismjs v3.0.0
1715bd9534ff190f14c10bdf13024af27a7f0ad115acf2b2b1cf6d848a8f5d52  v3.0.0.zip

- fox.jason.extend.css v1.0.1
c9260266c7ee6e46d178499ed9039e4a14a50ac37b161a44e06c01e7bbf099fe  v1.0.1.zip

- fox.jason.prismjs.dark-theme v1.0.1
befe437159c1762c0dd36838fa7f8c8d5e8bb468f8864caf3ce9e6e5ed7acd87  v1.0.1.zip

- fox.jason.readthedocs v1.3.0
468a78d43b8885a252fcb65c4150153100266d6fdbb44a6e218e6ef560442e69  v1.3.0.zip

- fox.jason.splash v2.2.0
185cbe02ced86b7a2943cf0096d6f233aff491df28a89dc0213aea6b63a68a7e  v2.2.0.zip

- fox.jason.translate.xliff v2.1.0
4c1705a7e43adf60fb0ca48ca3ce0725adeebd7ad05ad824c43fecd829a8fa5c  v2.1.0.zip

- fox.jason.unit-test v2.0.0
f94633f1617cd572e4dcc6a5d32e68d887072af96ff49d629bc87a25d06ca631  v2.0.0.zip
