### PR TITLE
Updating Releases compatible with DITA-OT 3.5

### DIFF
--- a/com.here.validate.svrl.json
+++ b/com.here.validate.svrl.json
@@ -50,5 +50,25 @@
     ],
     "url": "https://github.com/jason-fox/com.here.validate.svrl/archive/v4.0.0.zip",
     "cksum": "b9afa2df2d0f5c1edfe2af44dc05b9ba8286c8e81743ad21e766b0239d44cafe"
+  },
+  {
+    "name": "com.here.validate.svrl",
+    "description": "A structure, style and content linter for DITA, MDITA and Markdown documents.",
+    "keywords": ["validation", "lint"],
+    "homepage": "https://jason-fox.github.io/com.here.validate.svrl",
+    "vers": "4.1.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "org.doctales.xmltask",
+        "req": ">=1.16.1"
+      }
+    ],
+    "url": "https://github.com/jason-fox/com.here.validate.svrl/archive/v4.1.0.zip",
+    "cksum": "8d9c65ab723e1c8d5a1107e5e543401313be5383b500346048884b629f5e0300"
   }
 ]

--- a/com.here.validate.svrl.overrides.json
+++ b/com.here.validate.svrl.overrides.json
@@ -62,5 +62,29 @@
     ],
     "url": "https://github.com/jason-fox/com.here.validate.svrl.overrides/archive/v4.0.0.zip",
     "cksum": "b62089a7d7010c1cd973a88b17682b562091bb619dd59cf729ade51e702a4bcb"
+  },
+  {
+    "name": "com.here.validate.svrl.overrides",
+    "description": "Shows how to add, remove or extend the ruleset of the base DITA Validator (com.here.validate.svrl).",
+    "keywords": ["validation", "lint"],
+    "homepage": "https://github.com/jason-fox/com.here.validate.svrl.overrides/blob/master/README.md",
+    "vers": "4.1.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "org.doctales.xmltask",
+        "req": ">=1.16.1"
+      },
+      {
+        "name": "com.here.validate.svrl",
+        "req": ">=4.1.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/com.here.validate.svrl.overrides/archive/v4.1.0.zip",
+    "cksum": "339c1e0cb4505f6ffdb06fc1c42b8c62f9f0ce4c15d750ff2497887864ac5857"
   }
 ]

--- a/com.here.validate.svrl.text-rules.json
+++ b/com.here.validate.svrl.text-rules.json
@@ -62,5 +62,29 @@
     ],
     "url": "https://github.com/jason-fox/com.here.validate.svrl.text-rules/archive/v4.0.0.zip",
     "cksum": "34cdba1498d43519ac30bb6d7f8e2a7d3fade3a6e37f34e6255941ed321412ab"
+  },
+  {
+    "name": "com.here.validate.svrl.text-rules",
+    "description": "Simple rule-based spelling and grammar validation DITA-OT plug-in for text elements within DITA documents.",
+    "keywords": ["validation", "text-lint", "spell-checking", "grammar-checking"],
+    "homepage": "https://jason-fox.github.io/com.here.validate.svrl.text-rules",
+    "vers": "4.1.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "org.doctales.xmltask",
+        "req": ">=1.16.1"
+      },
+      {
+        "name": "com.here.validate.svrl",
+        "req": ">=4.1.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/com.here.validate.svrl.text-rules/archive/v4.1.0.zip",
+    "cksum": "49747de1d451dc621b467c05f06385a63bfd2d7be0bbbedd627167036d402aec"
   }
 ]

--- a/fox.jason.prismjs.json
+++ b/fox.jason.prismjs.json
@@ -138,5 +138,29 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.prismjs/archive/v3.0.0.zip",
     "cksum": "1715bd9534ff190f14c10bdf13024af27a7f0ad115acf2b2b1cf6d848a8f5d52"
+  },
+  {
+    "name": "fox.jason.prismjs",
+    "description": "An integration of Prism-JS into the DITA Open Toolkit engine, enabling static HTML and PDF syntax highlighting.",
+    "keywords": ["prismjs", "code-highlighter", "syntax-highlighting"],
+    "homepage": "https://jason-fox.github.io/fox.jason.prismjs",
+    "vers": "3.0.1",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.1.0"
+      },
+      {
+        "name": "org.doctales.xmltask",
+        "req": ">=1.16.1"
+      },
+      {
+        "name": "fox.jason.extend.css",
+        "req": ">=1.0.1"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.prismjs/archive/v3.0.1.zip",
+    "cksum": "860e3225fc5ae73fd7e23ce1e1c7b5571ec023fcb52faf58a8ba78226e347413"
   }
 ]

--- a/fox.jason.translate.xliff.json
+++ b/fox.jason.translate.xliff.json
@@ -54,5 +54,25 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.translate.xliff/archive/v2.1.0.zip",
     "cksum": "4c1705a7e43adf60fb0ca48ca3ce0725adeebd7ad05ad824c43fecd829a8fa5c"
+  },
+  {
+    "name": "fox.jason.translate.xliff",
+    "description": "Creates XLIFF from DITA, auto-translates and re-merges XLIFF files, generating translated documentation in a targeted foreign language.",
+    "keywords": ["xliff", "language-translation"],
+    "homepage": "https://jason-fox.github.io/fox.jason.translate.xliff",
+    "vers": "3.0.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "org.doctales.xmltask",
+        "req": ">=1.16.1"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.translate.xliff/archive/v3.0.0.zip",
+    "cksum": "f2609598407ba2b3cec4317ae1a537df873c6e40f97466666c8a8102a42d151e"
   }
 ]


### PR DESCRIPTION
* com.here.validate.svrl `v4.1.0`
* com.here.validate.svrl.text-rules `v4.1.0`
* com.here.validate.svrl.overrides `v4.1.0`
* fox.jason.pretty-dita `v1.4.1`
* fox.jason.prismjs `v3.0.1`
* fox.jason.translate.xliff `v3.0.0`