### PR TITLE
add com.amplexor.imagemap-pdf plugin entry file

### DIFF
--- a/com.amplexor.imagemap-pdf.json
+++ b/com.amplexor.imagemap-pdf.json
@@ -4,7 +4,7 @@
     "description": "DITA-OT plugin to manage imagemap element in PDF.",
     "keywords": ["Image map"],
     "homepage": "https://github.com/Amplexor/com.amplexor.imagemap-pdf/",
-    "vers": "1.0",
+    "vers": "1.0.0",
     "license": "Apache-2.0",
     "deps": [
       {

--- a/com.amplexor.imagemap-pdf.json
+++ b/com.amplexor.imagemap-pdf.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "com.amplexor.imagemap-pdf",
+    "description": "DITA-OT plugin to manage imagemap element in PDF.",
+    "keywords": ["Image map"],
+    "homepage": "https://github.com/Amplexor/com.amplexor.imagemap-pdf/",
+    "vers": "1.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      }
+    ],
+    "url": "https://github.com/Amplexor/com.amplexor.imagemap-pdf/releases/download/v1.0/com.amplexor.imagemap-pdf-v1.0.zip",
+    "cksum": "7AA384D01722EE8E8EC64E0B6E7B1F205B706577DE5604113EDDE1C455E401A3"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Nicolas Delobel <nicolas.delobel@amplexor.com>

---
name: Pull request
about: Propose changes to fix an issue or implement a new feature

---

## Description
Add com.amplexor.imagemap-pdf.json plugin entry file

## Motivation and Context
com.amplexor.imagemap-pdf is a DITA-OT plugin to manage imagemap element in PDF

## How Has This Been Tested?
Tested on DITA-OT 3.X. with Antenna House 6.6 and 7.x.
Some limitation exists with FOP (tested with FOP 2.4): internal link between image map area and an `@id` on dita content doesn't work.
