### PR TITLE
Prism release 3.0.2

### DIFF
--- a/fox.jason.prismjs.json
+++ b/fox.jason.prismjs.json
@@ -162,5 +162,29 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.prismjs/archive/v3.0.1.zip",
     "cksum": "860e3225fc5ae73fd7e23ce1e1c7b5571ec023fcb52faf58a8ba78226e347413"
+  },
+  {
+    "name": "fox.jason.prismjs",
+    "description": "An integration of Prism-JS into the DITA Open Toolkit engine, enabling static HTML and PDF syntax highlighting.",
+    "keywords": ["prismjs", "code-highlighter", "syntax-highlighting"],
+    "homepage": "https://jason-fox.github.io/fox.jason.prismjs",
+    "vers": "3.0.2",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.1.0"
+      },
+      {
+        "name": "org.doctales.xmltask",
+        "req": ">=1.16.1"
+      },
+      {
+        "name": "fox.jason.extend.css",
+        "req": ">=1.0.1"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.prismjs/archive/v3.0.2.zip",
+    "cksum": "c472d447bd07e9417865e2217d0f74952f131841c2ad687e7e567c1140d3138e"
   }
 ]


### PR DESCRIPTION
Ensure prerequisites are loaded

e.g For C++ highlighting you need to have loaded c beforehand.

```text
fox.jason.prismjs v3.0.2
c472d447bd07e9417865e2217d0f74952f131841c2ad687e7e567c1140d3138e  v3.0.2.zip
```