### PR TITLE
Addition of new watermark plugins

### DIFF
--- a/fox.jason.watermark.auth.json
+++ b/fox.jason.watermark.auth.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "fox.jason.watermark.auth",
+    "description": "Authorization of the watermarking of generated PDF files.",
+    "keywords": ["watermark", "authorization", "pdf"],
+    "homepage": "https://jason-fox.github.io/fox.jason.watermark.auth",
+    "vers": "1.0.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.watermark.auth/archive/v1.0.0.zip",
+    "cksum": "457edba202703c50bd14a976ede92a5da624e21685fd5fddeb5988c9bdaa103d"
+  }
+]

--- a/fox.jason.watermark.json
+++ b/fox.jason.watermark.json
@@ -13,6 +13,6 @@
       }
     ],
     "url": "https://github.com/jason-fox/fox.jason.watermark/archive/v1.0.0.zip",
-    "cksum": "ec39977619bb1c59f99dbedf7aa10ab739b76a6ae55edd292433a45d19c05f0f"
+    "cksum": "5584ede23a06e059405fc49327b8e6ae9e5eb3c10b1894b8ea8677bc824e34a8"
   }
 ]

--- a/fox.jason.watermark.json
+++ b/fox.jason.watermark.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "fox.jason.watermark",
+    "description": "Defaces draft PDFs with a watermark image",
+    "keywords": ["watermark", "pdf"],
+    "homepage": "https://jason-fox.github.io/fox.jason.watermark",
+    "vers": "1.0.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.watermark/archive/v1.0.0.zip",
+    "cksum": "ec39977619bb1c59f99dbedf7aa10ab739b76a6ae55edd292433a45d19c05f0f"
+  }
+]


### PR DESCRIPTION
---
name: Pull request
about: Addition of new watermark plugins

---

## Description

Adds a configurable background image to draft PDFs: 
![](https://jason-fox.github.io/fox.jason.watermark/watermark-pdf.png)

Currently limited to English (default), French and German texts.


## Motivation and Context

Avoid sending out draft documentation by mistake.

## How Has This Been Tested?

Install Plug-in, run local builds.

## Type of Changes

- New feature _(non-breaking change which adds functionality)_

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
