### PR TITLE
Simple tabs

### DIFF
--- a/fox.jason.tabs.css.json
+++ b/fox.jason.tabs.css.json
@@ -1,0 +1,27 @@
+[
+  {
+    "name": "fox.jason.tabs.css",
+    "description": "CSS-only tabbed dialog within DITA HTML output",
+    "keywords": [
+      "HTML",
+      "HTML5",
+      "tabs",
+      "css"
+    ],
+    "homepage": "https://jason-fox.github.io/fox.jason.tabs.css",
+    "vers": "1.0.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "fox.jason.extend.css",
+        "req": ">=1.1.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.tabs.css/archive/v1.0.0.zip",
+    "cksum": "fc7d3cfad967768e35be8ad0b8e76b3b217cee11d4ad1239a168bde806ca9f89"
+  }
+]


### PR DESCRIPTION
## Description

CSS-only HTML Tabbed Dialog DITA-OT Plug-in

## Motivation and Context

Annotated `<bodydiv>` `<section>`  elements can be displayed as separate tabs. No JavaScript necessary.

![](https://camo.githubusercontent.com/aa917dcfd9430e4f44aa2479a76564a1ab128b2002358af5f674cd1bd3892944/68747470733a2f2f6a61736f6e2d666f782e6769746875622e696f2f666f782e6a61736f6e2e746162732e6373732f7461626265642e706e67)

## How Has This Been Tested?

Automated test within plugin.

## Type of Changes

- New feature 

