### PR TITLE
Add DITA 2.0 pre-release grammars

### DIFF
--- a/org.oasis-open.dita.techcomm.v2_0.json
+++ b/org.oasis-open.dita.techcomm.v2_0.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "org.oasis-open.dita.techcomm.v2_0",
+    "description": "DITA 2.0 Technical Communication grammar plug-in for DITA-OT.",
+    "keywords": ["DITA", "OASIS", "beta"],
+    "homepage": "https://github.com/oasis-tcs/dita-techcomm/",
+    "vers": "2.0.0-20211007",
+    "license": "SEE LICENSE IN https://github.com/oasis-tcs/dita-techcomm/blob/DITA-2.0/LICENSE.md",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      }
+    ],
+    "url": "https://github.com/dita-ot/dita-techcomm/releases/download/2.0.0-20211007/org.oasis-open.dita.techcomm.v2_0.zip",
+    "cksum": "493c81c912c85e745d66cc2c76429234b2102050c1f663eb108a224d6feead9b"
+  }
+]

--- a/org.oasis-open.dita.v2_0.json
+++ b/org.oasis-open.dita.v2_0.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "org.oasis-open.dita.v2_0",
+    "description": "DITA 2.0 base grammar plug-in for DITA-OT.",
+    "keywords": ["DITA", "OASIS", "beta"],
+    "homepage": "https://github.com/oasis-tcs/dita/",
+    "vers": "2.0.0-20211007",
+    "license": "SEE LICENSE IN https://github.com/oasis-tcs/dita/blob/master/LICENSE.md",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      }
+    ],
+    "url": "https://github.com/dita-ot/dita/releases/download/2.0.0-20211007/org.oasis-open.dita.v2_0.zip",
+    "cksum": "83a7ef733de9f86fc2988471af040583cba672a7fd3033e577209d89074c2990"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <gorodki@gmail.com>

## Description

Plugins with latest beta versions of DITA 2.0 grammar files, as of Oct 7 2021.

## Motivation and Context

Allows testing of latest grammar

## How Has This Been Tested?

Passes build in https://github.com/dita-ot/dita-ot/pull/3809

## Type of Changes

n/a
