### PR TITLE
Plug-in Releases for DITA-OT 3.7

### DIFF
--- a/fox.jason.audiobook.json
+++ b/fox.jason.audiobook.json
@@ -2,7 +2,12 @@
   {
     "name": "fox.jason.audiobook",
     "description": "Transforms DITA to speech in the form of an audiobook. It uses freely available Text-to-Speech cloud services to transform SSML files into MP3 audio files or a single m4a audiobook.",
-    "keywords": ["speech-synthesis", "audio-processing", "audiobook", "text-to-speech"],
+    "keywords": [
+      "speech-synthesis",
+      "audio-processing",
+      "audiobook",
+      "text-to-speech"
+    ],
     "homepage": "https://jason-fox.github.io/fox.jason.audiobook",
     "vers": "1.0.0",
     "license": "Apache-2.0",
@@ -18,7 +23,12 @@
   {
     "name": "fox.jason.audiobook",
     "description": "Transforms DITA to speech in the form of an audiobook. It uses freely available Text-to-Speech cloud services to transform SSML files into MP3 audio files or a single m4a audiobook.",
-    "keywords": ["speech-synthesis", "audio-processing", "audiobook", "text-to-speech"],
+    "keywords": [
+      "speech-synthesis",
+      "audio-processing",
+      "audiobook",
+      "text-to-speech"
+    ],
     "homepage": "https://jason-fox.github.io/fox.jason.audiobook",
     "vers": "1.1.0",
     "license": "Apache-2.0",
@@ -34,7 +44,12 @@
   {
     "name": "fox.jason.audiobook",
     "description": "Transforms DITA to speech in the form of an audiobook. It uses freely available Text-to-Speech cloud services to transform SSML files into MP3 audio files or a single m4a audiobook.",
-    "keywords": ["speech-synthesis", "audio-processing", "audiobook", "text-to-speech"],
+    "keywords": [
+      "speech-synthesis",
+      "audio-processing",
+      "audiobook",
+      "text-to-speech"
+    ],
     "homepage": "https://jason-fox.github.io/fox.jason.audiobook",
     "vers": "1.2.0",
     "license": "Apache-2.0",
@@ -50,7 +65,12 @@
   {
     "name": "fox.jason.audiobook",
     "description": "Transforms DITA to speech in the form of an audiobook. It uses freely available Text-to-Speech cloud services to transform SSML files into MP3 audio files or a single m4a audiobook.",
-    "keywords": ["speech-synthesis", "audio-processing", "audiobook", "text-to-speech"],
+    "keywords": [
+      "speech-synthesis",
+      "audio-processing",
+      "audiobook",
+      "text-to-speech"
+    ],
     "homepage": "https://jason-fox.github.io/fox.jason.audiobook",
     "vers": "1.3.0",
     "license": "Apache-2.0",
@@ -62,5 +82,26 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.audiobook/archive/v1.3.0.zip",
     "cksum": "c94350783c1d165b175aa950cd4c6678b117b3d6b84a02309fb68361f3b58475"
+  },
+  {
+    "name": "fox.jason.audiobook",
+    "description": "Transforms DITA to speech in the form of an audiobook. It uses freely available Text-to-Speech cloud services to transform SSML files into MP3 audio files or a single m4a audiobook.",
+    "keywords": [
+      "speech-synthesis",
+      "audio-processing",
+      "audiobook",
+      "text-to-speech"
+    ],
+    "homepage": "https://jason-fox.github.io/fox.jason.audiobook",
+    "vers": "1.3.1",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.audiobook/archive/v1.3.1.zip",
+    "cksum": "3057aa4e625c7f537381f8887d485bcebbfa033016534eaa9df6206e72bfcc1c"
   }
 ]

--- a/fox.jason.extend.css.json
+++ b/fox.jason.extend.css.json
@@ -93,5 +93,24 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.extend.css/archive/v1.1.0.zip",
     "cksum": "b87ae00f2ac56f02f1e46f6c2581afda124df5d7e74b6db0b23d87a5323816b8"
+  },
+  {
+    "name": "fox.jason.extend.css",
+    "description": "Extension to allow additional plug-ins to add an extra CSS stylesheet to HTML pages.",
+    "keywords": [
+      "html",
+      "css"
+    ],
+    "homepage": "https://jason-fox.github.io/fox.jason.extend.css",
+    "vers": "1.2.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.1.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.extend.css/archive/v1.2.0.zip",
+    "cksum": "4cfe30bd265ad3a96d4a62d31a5b5577e8239285a0419bd4a8e7bdf6443e2ad7"
   }
 ]

--- a/fox.jason.passthrough.json
+++ b/fox.jason.passthrough.json
@@ -148,5 +148,23 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.passthrough/archive/v4.0.0.zip",
     "cksum": "ed7eb03c86233e847987f8bc74b4eafb74a402fb690bb37d4c58791fef04d92c"
+  },
+  {
+    "name": "fox.jason.passthrough",
+    "description": "Plug-in to enable files to bypass DITA-OT pre-processing",
+    "keywords": [
+      "passthrough"
+    ],
+    "homepage": "https://jason-fox.github.io/fox.jason.passthrough",
+    "vers": "4.1.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.passthrough/archive/v4.1.0.zip",
+    "cksum": "d1dbea2529be790ac4550f417fed5b16c56dfe98315af78361813526293a5ce9"
   }
 ]

--- a/fox.jason.passthrough.pandoc.json
+++ b/fox.jason.passthrough.pandoc.json
@@ -206,5 +206,37 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.passthrough.pandoc/archive/v2.0.1.zip",
     "cksum": "ab3a91c6fab79f597585392a8bf581f81fb8981c52d5bce19ea55cf71fa72c38"
+  },
+  {
+    "name": "fox.jason.passthrough.pandoc",
+    "description": "Pandoc Plug-in for extending the available input formats for DITA-OT. Non DITA input sources can be pre-processed to create create valid DITA source.",
+    "keywords": [
+      "pandoc",
+      "DocBook",
+      "HTML",
+      "markdown",
+      "MS Word",
+      "docx",
+      "odt",
+      "wiki",
+      "rst",
+      "epub",
+      "latex"
+    ],
+    "homepage": "https://jason-fox.github.io/fox.jason.passthrough.pandoc",
+    "vers": "2.1.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "fox.jason.passthrough",
+        "req": ">=4.0.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.passthrough.pandoc/archive/v2.1.0.zip",
+    "cksum": "4db6f97780dd6ba6dce75ec16d069f86221d4db4f33de660c9dad40466cf93ae"
   }
 ]

--- a/fox.jason.passthrough.swagger.json
+++ b/fox.jason.passthrough.swagger.json
@@ -206,5 +206,37 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.passthrough.swagger/archive/v2.0.0.zip",
     "cksum": "a1a0b390107f8d5f5bd952ee916deeb2996f8bb990515d20dbe700238e991600"
+  },
+  {
+    "name": "fox.jason.passthrough.swagger",
+    "description": "DITA-OT Plug-in to automatically create REST API documentation from a Swagger definition",
+    "keywords": [
+      "swagger",
+      "REST",
+      "auto-generated text"
+    ],
+    "homepage": "https://jason-fox.github.io/fox.jason.passthrough.swagger",
+    "vers": "2.0.1",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "fox.jason.extend.css",
+        "req": ">=1.0.3"
+      },
+      {
+        "name": "fox.jason.passthrough",
+        "req": ">=4.0.0"
+      },
+      {
+        "name": "fox.jason.passthrough.pandoc",
+        "req": ">=2.0.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.passthrough.swagger/archive/v2.0.1.zip",
+    "cksum": "d2ed32be087204a2a9dd2c94611284641b7208c83b07bf4892e9d2e008ce5ec8"
   }
 ]

--- a/fox.jason.pretty-dita.json
+++ b/fox.jason.pretty-dita.json
@@ -118,5 +118,25 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.pretty-dita/archive/v1.5.1.zip",
     "cksum": "62ad781c9e145e1dc3bd47f0f37a328ab0a94b930ab0a27904ff4e662fc1f365"
+  },
+  {
+    "name": "fox.jason.pretty-dita",
+    "description": "A DITA prettifier DITA-OT Plug-in which formats DITA XML in an aesthetically pleasing manner.",
+    "keywords": [
+      "pretty-print",
+      "dita",
+      "formatting"
+    ],
+    "homepage": "https://jason-fox.github.io/fox.jason.pretty-dita",
+    "vers": "1.6.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.pretty-dita/archive/v1.6.0.zip",
+    "cksum": "ef5bc9ad5ec3395c126e4d998606498f0fa0f6eead553e13fa6e7d4baedf2894"
   }
 ]

--- a/fox.jason.prismjs.dark-theme.json
+++ b/fox.jason.prismjs.dark-theme.json
@@ -2,7 +2,12 @@
   {
     "name": "fox.jason.prismjs.dark-theme",
     "description": "Extension of the DITA-OT Prism-JS plug-in to amend the look-and-feel of highlighted code. Offers the standard Dark Theme from Prism-JS.",
-    "keywords": ["prismjs", "code-highlighter", "syntax-highlighting", "css"],
+    "keywords": [
+      "prismjs",
+      "code-highlighter",
+      "syntax-highlighting",
+      "css"
+    ],
     "homepage": "https://jason-fox.github.io/fox.jason.prismjs.dark-theme",
     "vers": "1.0.0",
     "license": "Apache-2.0",
@@ -26,7 +31,12 @@
   {
     "name": "fox.jason.prismjs.dark-theme",
     "description": "Extension of the DITA-OT Prism-JS plug-in to amend the look-and-feel of highlighted code. Offers the standard Dark Theme from Prism-JS.",
-    "keywords": ["prismjs", "code-highlighter", "syntax-highlighting", "css"],
+    "keywords": [
+      "prismjs",
+      "code-highlighter",
+      "syntax-highlighting",
+      "css"
+    ],
     "homepage": "https://jason-fox.github.io/fox.jason.prismjs.dark-theme",
     "vers": "1.0.0",
     "license": "Apache-2.0",
@@ -46,5 +56,34 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.prismjs.dark-theme/archive/v1.0.1.zip",
     "cksum": "befe437159c1762c0dd36838fa7f8c8d5e8bb468f8864caf3ce9e6e5ed7acd87"
+  },
+  {
+    "name": "fox.jason.prismjs.dark-theme",
+    "description": "Extension of the DITA-OT Prism-JS plug-in to amend the look-and-feel of highlighted code. Offers the standard Dark Theme from Prism-JS.",
+    "keywords": [
+      "prismjs",
+      "code-highlighter",
+      "syntax-highlighting",
+      "css"
+    ],
+    "homepage": "https://jason-fox.github.io/fox.jason.prismjs.dark-theme",
+    "vers": "1.0.2",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.1.0"
+      },
+      {
+        "name": "fox.jason.extend.css",
+        "req": ">=1.0.3"
+      },
+      {
+        "name": "fox.jason.prismjs",
+        "req": ">=3.0.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.prismjs.dark-theme/archive/v1.0.2.zip",
+    "cksum": "f35dd6e9ae5823348269141f9862e83c7f73bed9e81ded610a3f8d8f351640d8"
   }
 ]

--- a/fox.jason.prismjs.json
+++ b/fox.jason.prismjs.json
@@ -322,5 +322,29 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.prismjs/archive/v3.2.2.zip",
     "cksum": "a8f7c18ea22c8d7a380f5c5b90a0d30799b32b7de1268b966810dac81635a3e7"
+  },
+  {
+    "name": "fox.jason.prismjs",
+    "description": "An integration of Prism-JS into the DITA Open Toolkit engine, enabling static HTML and PDF syntax highlighting.",
+    "keywords": [
+      "prismjs",
+      "code-highlighter",
+      "syntax-highlighting"
+    ],
+    "homepage": "https://jason-fox.github.io/fox.jason.prismjs",
+    "vers": "3.2.3",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.1.0"
+      },
+      {
+        "name": "fox.jason.extend.css",
+        "req": ">=1.1.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.prismjs/archive/v3.2.3.zip",
+    "cksum": "4699bb7db79313f3b233d0d5e658bf287ea65f10147ac93f4fec9f4cd5ed6cc0"
   }
 ]

--- a/fox.jason.readthedocs.json
+++ b/fox.jason.readthedocs.json
@@ -117,5 +117,29 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.readthedocs/archive/v1.4.0.zip",
     "cksum": "b7e9954f824d8af6b8a511fdc1a3f8946fa7d697c30093a1b513e7929ce690aa"
+  },
+  {
+    "name": "fox.jason.readthedocs",
+    "description": "Plug-in to create a set of output files suitable for a ReadTheDocs documentation project",
+    "keywords": [
+      "readthedocs",
+      "markdown",
+      "mkdocs"
+    ],
+    "homepage": "https://jason-fox.github.io/fox.jason.readthedocs",
+    "vers": "1.4.1",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "org.lwdita",
+        "req": ">=2.2.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.readthedocs/archive/v1.4.1.zip",
+    "cksum": "087b6a5cee518128a76528111f2cf4d9db87cda824b16ad86a4e6392e337e55b"
   }
 ]

--- a/fox.jason.splash.json
+++ b/fox.jason.splash.json
@@ -2,7 +2,11 @@
   {
     "name": "fox.jason.splash",
     "description": "Splash Screen Plug-in for DITA-OT.",
-    "keywords": ["splash-screen", "xkcd", "cats"],
+    "keywords": [
+      "splash-screen",
+      "xkcd",
+      "cats"
+    ],
     "homepage": "https://jason-fox.github.io/fox.jason.splash",
     "vers": "1.0.2",
     "license": "Apache-2.0",
@@ -18,7 +22,11 @@
   {
     "name": "fox.jason.splash",
     "description": "Splash Screen Plug-in for DITA-OT.",
-    "keywords": ["splash-screen", "xkcd", "cats"],
+    "keywords": [
+      "splash-screen",
+      "xkcd",
+      "cats"
+    ],
     "homepage": "https://jason-fox.github.io/fox.jason.splash",
     "vers": "2.0.0",
     "license": "Apache-2.0",
@@ -34,7 +42,11 @@
   {
     "name": "fox.jason.splash",
     "description": "Splash Screen Plug-in for DITA-OT.",
-    "keywords": ["splash-screen", "xkcd", "cats"],
+    "keywords": [
+      "splash-screen",
+      "xkcd",
+      "cats"
+    ],
     "homepage": "https://jason-fox.github.io/fox.jason.splash",
     "vers": "2.1.0",
     "license": "Apache-2.0",
@@ -50,7 +62,11 @@
   {
     "name": "fox.jason.splash",
     "description": "Splash Screen Plug-in for DITA-OT.",
-    "keywords": ["splash-screen", "xkcd", "cats"],
+    "keywords": [
+      "splash-screen",
+      "xkcd",
+      "cats"
+    ],
     "homepage": "https://jason-fox.github.io/fox.jason.splash",
     "vers": "2.2.0",
     "license": "Apache-2.0",
@@ -62,5 +78,25 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.splash/archive/v2.2.0.zip",
     "cksum": "185cbe02ced86b7a2943cf0096d6f233aff491df28a89dc0213aea6b63a68a7e"
+  },
+  {
+    "name": "fox.jason.splash",
+    "description": "Splash Screen Plug-in for DITA-OT.",
+    "keywords": [
+      "splash-screen",
+      "xkcd",
+      "cats"
+    ],
+    "homepage": "https://jason-fox.github.io/fox.jason.splash",
+    "vers": "2.2.1",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.splash/archive/v2.2.1.zip",
+    "cksum": "db9b5d4db559ea4a5af099ec3999bf700400484005f73afc3ee61f40b408003d"
   }
 ]

--- a/fox.jason.translate.xliff.json
+++ b/fox.jason.translate.xliff.json
@@ -155,5 +155,28 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.translate.xliff/archive/v3.3.0.zip",
     "cksum": "093aefe9c78fd4f914b3aaea8a94b32046de593034e4e6f6ef5fb90a4f2fbe96"
+  },
+  {
+    "name": "fox.jason.translate.xliff",
+    "description": "Creates XLIFF from DITA, auto-translates and re-merges XLIFF files, generating translated documentation in a targeted foreign language.",
+    "keywords": [
+      "xliff",
+      "language-translation"
+    ],
+    "homepage": "https://jason-fox.github.io/fox.jason.translate.xliff",
+    "vers": "3.4.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "org.doctales.xmltask",
+        "req": ">=1.16.1"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.translate.xliff/archive/v3.4.0.zip",
+    "cksum": "05f5fa760f7049191924f967ec5a23be957907596119c3f6bcf0d34c24cd941c"
   }
 ]


### PR DESCRIPTION
## Description

-  Update fox.jason.translate.xliff to 3.4.0
-  Update fox.jason.splash to 2.2.1 
-  Update fox.jason.readthedocs to 1.4.1 
-  Update fox.jason.pretty-dita to 1.6.0 
-  Update fox.jason.prismjs.dark-theme to 1.0.2 
-  Update fox.jason.prismjs to 3.2.3 
-  Update fox.jason.passthrough.swagger to 2.0.1 
-  Update fox.jason.passthrough.pandoc to 2.1.0 
-  Update fox.jason.passthrough to 4.1.0 
-  Update fox.jason.extend.css to 1.2.0 
-  Update fox.jason.extend.css to 1.2.0 
-  Update fox.jason.audiobook to 1.3.1

## Motivation and Context

Updates for DITA-OT 3.7

## How Has This Been Tested?

Updated unit tests on each plugin to use DITA-OT 3.7, rerun tests.

## Type of Changes

Bug fixes and alignment to DITA-OT 3.7 XSLT

## Documentation and Compatibility

Documentation is found here: https://jason-fox.github.io/dita-ot-plugins/

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
