### PR TITLE
Add favicon plugin

### DIFF
--- a/fox.jason.favicon.json
+++ b/fox.jason.favicon.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "fox.jason.favicon",
+    "description": "Adds a favicon to DITA HTML output.",
+    "keywords": [
+      "html",
+      "css"
+    ],
+    "homepage": "https://jason-fox.github.io/fox.jason.favicon",
+    "vers": "1.0.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.1.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.favicon/archive/v1.0.0.zip",
+    "cksum": "494cf0d2d4efb4d254873bec4360e67c7fc1c816e95baee4bd350b3ec5b77867"
+  }
+]


### PR DESCRIPTION
## Description

A DITA-OT Plug-in used to add a favicon to DITA HTML output.

![favicon](https://user-images.githubusercontent.com/3439249/151866443-f0be6e52-34a2-4e5c-a4db-5194493af7be.png)




To run, use any `html` transform and add the `args.favicon`, `args.faviconpath` and `args.faviconroot` parameters.
The new `args.favicon.*` parameters follow the existing syntax used by DITA-OT for CSS files.

```console
PATH_TO_DITA_OT/bin/dita -f [html5|xhtml]  -o out -i PATH_TO_DITAMAP \
  --args.favicon=FILENAME \
  --args.faviconpath=DESTINATION_PATH_OF_FAVICON  \
  --args.faviconroot=SOURCE_PATH_OF_FAVICON \
```

To refer to an exisiting file hosted on a server, use a URL as the `args.faviconpath` parameter

```console
PATH_TO_DITA_OT/bin/dita -f [html5|xhtml]  -o out -i PATH_TO_DITAMAP \
  --args.favicon=FILENAME \
  --args.faviconpath=https://example.com/static/assets
```

## Motivation and Context

HTML outputs currently lack an option to add a [favicon](https://en.wikipedia.org/wiki/Favicon) - simple plugin to add  `<link rel="shortcut icon" href="../favicon/favicon.svg">` to the `<head>` using the same parameter schema as the existing CSS imports

## How Has This Been Tested?

Local testing - online example can be found here: https://jason-fox.github.io/dita-ot-plugins/

## Type of Changes

- New Feature

## Documentation and Compatibility

Documentation added here: https://jason-fox.github.io/dita-ot-plugins/favicon/index.html

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
