### PR TITLE
Added dita-bootstrap 5.3.1 release

### DIFF
--- a/net.infotexture.dita-bootstrap.json
+++ b/net.infotexture.dita-bootstrap.json
@@ -110,5 +110,21 @@
     ],
     "url": "https://github.com/infotexture/dita-bootstrap/archive/5.3.zip",
     "cksum": "b3fae75957c1be8d55551f111763e038bec55252cb367089aeea8689d7cddf2d"
+  },
+  {
+    "name": "net.infotexture.dita-bootstrap",
+    "description": "HTML5 output with a basic Bootstrap template",
+    "keywords": ["HTML", "HTML5", "Bootstrap", "Bootstrap 5", "Responsive"],
+    "homepage": "https://infotexture.github.io/dita-bootstrap",
+    "vers": "5.3.1",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.6.0"
+      }
+    ],
+    "url": "https://github.com/infotexture/dita-bootstrap/archive/5.3.1.zip",
+    "cksum": "b236c00e65a2895159f098318c96f7e042d2b64784587c1100d6c4f39df926b4"
   }
 ]


### PR DESCRIPTION
### Description
Bootstrap 5.1 support for DITA-OT 3.x per https://github.com/infotexture/dita-bootstrap/releases/tag/5.3.1

The plug-in has been updated to use [Bootstrap 5.1](https://blog.getbootstrap.com/2021/10/05/bootstrap-5-1-2/) and [Bootstrap Icons 1.8](https://blog.getbootstrap.com/2022/01/31/bootstrap-icons-1-8-0/) and adds further additional support for Bootstrap components.