### PR TITLE
 fox.jason.prismjs 3.3.0 and fox.jason.translate.xliff  3.5.0 Releases

### DIFF
--- a/fox.jason.prismjs.json
+++ b/fox.jason.prismjs.json
@@ -346,5 +346,29 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.prismjs/archive/v3.2.3.zip",
     "cksum": "4699bb7db79313f3b233d0d5e658bf287ea65f10147ac93f4fec9f4cd5ed6cc0"
+  },
+  {
+    "name": "fox.jason.prismjs",
+    "description": "An integration of Prism-JS into the DITA Open Toolkit engine, enabling static HTML and PDF syntax highlighting.",
+    "keywords": [
+      "prismjs",
+      "code-highlighter",
+      "syntax-highlighting"
+    ],
+    "homepage": "https://jason-fox.github.io/fox.jason.prismjs",
+    "vers": "3.3.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.1.0"
+      },
+      {
+        "name": "fox.jason.extend.css",
+        "req": ">=1.1.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.prismjs/archive/v3.3.0.zip",
+    "cksum": "6b186d3001c21c0d3b8933f47142cbdb19c034fbb1b3768bb60f89f2a60878e1"
   }
 ]

--- a/fox.jason.translate.xliff.json
+++ b/fox.jason.translate.xliff.json
@@ -178,5 +178,28 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.translate.xliff/archive/v3.4.0.zip",
     "cksum": "05f5fa760f7049191924f967ec5a23be957907596119c3f6bcf0d34c24cd941c"
+  },
+  {
+    "name": "fox.jason.translate.xliff",
+    "description": "Creates XLIFF from DITA, auto-translates and re-merges XLIFF files, generating translated documentation in a targeted foreign language.",
+    "keywords": [
+      "xliff",
+      "language-translation"
+    ],
+    "homepage": "https://jason-fox.github.io/fox.jason.translate.xliff",
+    "vers": "3.5.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      },
+      {
+        "name": "org.doctales.xmltask",
+        "req": ">=1.16.1"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.translate.xliff/archive/v3.5.0.zip",
+    "cksum": "c5cc7e916849a2fa04dbc875f309091822d1dbebcdc8f48d100eb07f31eec7a2"
   }
 ]


### PR DESCRIPTION
## Description

Update fox.jason.prismjs to 3.3.0
Update fox.jason.translate.xliff to 3.5.0

## Motivation and Context

- Adds Dark Mode Support to prismjs
- Adds `@translate="no"` and `@translate="yes"` to XLIFF plugin
