### PR TITLE
DITA-OT 4.0 Compatibility Releases

### DIFF
--- a/fox.jason.audiobook.json
+++ b/fox.jason.audiobook.json
@@ -103,5 +103,26 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.audiobook/archive/v1.3.1.zip",
     "cksum": "3057aa4e625c7f537381f8887d485bcebbfa033016534eaa9df6206e72bfcc1c"
+  },
+  {
+    "name": "fox.jason.audiobook",
+    "description": "Transforms DITA to speech in the form of an audiobook. It uses freely available Text-to-Speech cloud services to transform SSML files into MP3 audio files or a single m4a audiobook.",
+    "keywords": [
+      "speech-synthesis",
+      "audio-processing",
+      "audiobook",
+      "text-to-speech"
+    ],
+    "homepage": "https://jason-fox.github.io/fox.jason.audiobook",
+    "vers": "2.0.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.audiobook/archive/v2.0.0.zip",
+    "cksum": "c6f915ecb87c3921e1be620fd9273289a98d08eb0859b650850dbec8b353f6ec"
   }
 ]

--- a/fox.jason.audiobook.json
+++ b/fox.jason.audiobook.json
@@ -14,7 +14,7 @@
     "deps": [
       {
         "name": "org.dita.base",
-        "req": ">=3.0.0"
+        "req": "3.0.0 - 3.7.4"
       }
     ],
     "url": "https://github.com/jason-fox/fox.jason.audiobook/archive/v1.0.0.zip",
@@ -35,7 +35,7 @@
     "deps": [
       {
         "name": "org.dita.base",
-        "req": ">=3.0.0"
+        "req": "3.0.0 - 3.7.4"
       }
     ],
     "url": "https://github.com/jason-fox/fox.jason.audiobook/archive/v1.1.0.zip",
@@ -56,7 +56,7 @@
     "deps": [
       {
         "name": "org.dita.base",
-        "req": ">=3.0.0"
+        "req": "3.0.0 - 3.7.4"
       }
     ],
     "url": "https://github.com/jason-fox/fox.jason.audiobook/archive/v1.2.0.zip",
@@ -77,7 +77,7 @@
     "deps": [
       {
         "name": "org.dita.base",
-        "req": ">=3.0.0"
+        "req": "3.0.0 - 3.7.4"
       }
     ],
     "url": "https://github.com/jason-fox/fox.jason.audiobook/archive/v1.3.0.zip",
@@ -98,7 +98,7 @@
     "deps": [
       {
         "name": "org.dita.base",
-        "req": ">=3.0.0"
+        "req": ">3.0.0 - 3.7.4"
       }
     ],
     "url": "https://github.com/jason-fox/fox.jason.audiobook/archive/v1.3.1.zip",

--- a/fox.jason.audiobook.json
+++ b/fox.jason.audiobook.json
@@ -119,7 +119,7 @@
     "deps": [
       {
         "name": "org.dita.base",
-        "req": ">=3.0.0"
+        "req": ">=4.0.0"
       }
     ],
     "url": "https://github.com/jason-fox/fox.jason.audiobook/archive/v2.0.0.zip",

--- a/fox.jason.audiobook.json
+++ b/fox.jason.audiobook.json
@@ -98,7 +98,7 @@
     "deps": [
       {
         "name": "org.dita.base",
-        "req": ">3.0.0 - 3.7.4"
+        "req": "3.0.0 - 3.7.4"
       }
     ],
     "url": "https://github.com/jason-fox/fox.jason.audiobook/archive/v1.3.1.zip",

--- a/fox.jason.prismjs.json
+++ b/fox.jason.prismjs.json
@@ -370,5 +370,29 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.prismjs/archive/v3.3.0.zip",
     "cksum": "6b186d3001c21c0d3b8933f47142cbdb19c034fbb1b3768bb60f89f2a60878e1"
+  },
+  {
+    "name": "fox.jason.prismjs",
+    "description": "An integration of Prism-JS into the DITA Open Toolkit engine, enabling static HTML and PDF syntax highlighting.",
+    "keywords": [
+      "prismjs",
+      "code-highlighter",
+      "syntax-highlighting"
+    ],
+    "homepage": "https://jason-fox.github.io/fox.jason.prismjs",
+    "vers": "4.0.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.1.0"
+      },
+      {
+        "name": "fox.jason.extend.css",
+        "req": ">=1.1.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.prismjs/archive/v4.0.0.zip",
+    "cksum": "6ef34d276d05656c0373a69e33d724d0b0494d2f49c2a23b4be9f4ed762cc855"
   }
 ]

--- a/fox.jason.prismjs.json
+++ b/fox.jason.prismjs.json
@@ -389,7 +389,7 @@
       },
       {
         "name": "fox.jason.extend.css",
-        "req": ">=1.1.0"
+        "req": ">=1.2.1"
       }
     ],
     "url": "https://github.com/jason-fox/fox.jason.prismjs/archive/v4.0.0.zip",

--- a/fox.jason.prismjs.json
+++ b/fox.jason.prismjs.json
@@ -385,7 +385,7 @@
     "deps": [
       {
         "name": "org.dita.base",
-        "req": ">=3.1.0"
+        "req": ">=4.0.0"
       },
       {
         "name": "fox.jason.extend.css",

--- a/fox.jason.prismjs.json
+++ b/fox.jason.prismjs.json
@@ -13,7 +13,7 @@
     "deps": [
       {
         "name": "org.dita.base",
-        "req": ">=3.1.0"
+        "req": "3.1.0 - 3.7.4"
       }
     ],
     "url": "https://github.com/jason-fox/fox.jason.prismjs/archive/v1.0.0.zip",
@@ -33,7 +33,7 @@
     "deps": [
       {
         "name": "org.dita.base",
-        "req": ">=3.1.0"
+        "req": "3.1.0 - 3.7.4"
       }
     ],
     "url": "https://github.com/jason-fox/fox.jason.prismjs/archive/v1.0.1.zip",
@@ -53,7 +53,7 @@
     "deps": [
       {
         "name": "org.dita.base",
-        "req": ">=3.1.0"
+        "req": "3.1.0 - 3.7.4"
       }
     ],
     "url": "https://github.com/jason-fox/fox.jason.prismjs/archive/v1.0.2.zip",
@@ -73,7 +73,7 @@
     "deps": [
       {
         "name": "org.dita.base",
-        "req": ">=3.1.0"
+        "req": "3.1.0 - 3.7.4"
       },
       {
         "name": "org.doctales.xmltask",
@@ -97,7 +97,7 @@
     "deps": [
       {
         "name": "org.dita.base",
-        "req": ">=3.1.0"
+        "req": "3.1.0 - 3.7.4"
       },
       {
         "name": "org.doctales.xmltask",
@@ -125,7 +125,7 @@
     "deps": [
       {
         "name": "org.dita.base",
-        "req": ">=3.1.0"
+        "req": "3.1.0 - 3.7.4"
       },
       {
         "name": "org.doctales.xmltask",
@@ -153,7 +153,7 @@
     "deps": [
       {
         "name": "org.dita.base",
-        "req": ">=3.1.0"
+        "req": "3.1.0 - 3.7.4"
       },
       {
         "name": "org.doctales.xmltask",
@@ -181,7 +181,7 @@
     "deps": [
       {
         "name": "org.dita.base",
-        "req": ">=3.1.0"
+        "req": "3.1.0 - 3.7.4"
       },
       {
         "name": "org.doctales.xmltask",
@@ -209,7 +209,7 @@
     "deps": [
       {
         "name": "org.dita.base",
-        "req": ">=3.1.0"
+        "req": "3.1.0 - 3.7.4"
       },
       {
         "name": "org.doctales.xmltask",
@@ -237,7 +237,7 @@
     "deps": [
       {
         "name": "org.dita.base",
-        "req": ">=3.1.0"
+        "req": "3.1.0 - 3.7.4"
       },
       {
         "name": "org.doctales.xmltask",
@@ -265,7 +265,7 @@
     "deps": [
       {
         "name": "org.dita.base",
-        "req": ">=3.1.0"
+        "req": "3.1.0 - 3.7.4"
       },
       {
         "name": "fox.jason.extend.css",
@@ -289,7 +289,7 @@
     "deps": [
       {
         "name": "org.dita.base",
-        "req": ">=3.1.0"
+        "req": "3.1.0 - 3.7.4"
       },
       {
         "name": "fox.jason.extend.css",
@@ -313,7 +313,7 @@
     "deps": [
       {
         "name": "org.dita.base",
-        "req": ">=3.1.0"
+        "req": "3.1.0 - 3.7.4"
       },
       {
         "name": "fox.jason.extend.css",
@@ -337,7 +337,7 @@
     "deps": [
       {
         "name": "org.dita.base",
-        "req": ">=3.1.0"
+        "req": "3.1.0 - 3.7.4"
       },
       {
         "name": "fox.jason.extend.css",
@@ -361,7 +361,7 @@
     "deps": [
       {
         "name": "org.dita.base",
-        "req": ">=3.1.0"
+        "req": "3.1.0 - 3.7.4"
       },
       {
         "name": "fox.jason.extend.css",

--- a/fox.jason.readthedocs.json
+++ b/fox.jason.readthedocs.json
@@ -141,5 +141,29 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.readthedocs/archive/v1.4.1.zip",
     "cksum": "087b6a5cee518128a76528111f2cf4d9db87cda824b16ad86a4e6392e337e55b"
+  },
+  {
+    "name": "fox.jason.readthedocs",
+    "description": "Plug-in to create a set of output files suitable for a ReadTheDocs documentation project",
+    "keywords": [
+      "readthedocs",
+      "markdown",
+      "mkdocs"
+    ],
+    "homepage": "https://jason-fox.github.io/fox.jason.readthedocs",
+    "vers": "2.0.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=4.0.0"
+      },
+      {
+        "name": "org.lwdita",
+        "req": ">=3.3.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.readthedocs/archive/v2.0.0.zip",
+    "cksum": "7cfe3d62fd1b93f9de6d1c6a8339f41d2bb50c051e0705ca93210a5e08c91746"
   }
 ]

--- a/fox.jason.unit-test.json
+++ b/fox.jason.unit-test.json
@@ -98,5 +98,25 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.unit-test/archive/v2.1.1.zip",
     "cksum": "868531937120c91a6e42d3f6589839b9ff3aba12e942cd71f912e21603168234"
+  },
+  {
+    "name": "fox.jason.unit-test",
+    "description": "Unit Testing and Code Coverage Framework for DITA-OT.",
+    "keywords": [
+      "unit-testing",
+      "code-coverage",
+      "profiling"
+    ],
+    "homepage": "https://jason-fox.github.io/fox.jason.unit-test",
+    "vers": "2.2.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.unit-test/archive/v2.2.0.zip",
+    "cksum": "8addda2f20e61e4d0ef90f0f225048a5bdd5170e0575550c58c0b23b96ec6966"
   }
 ]


### PR DESCRIPTION
## Description
Update fox.jason.unit-test 2.2.0
Update fox.jason.audiobook 2.0.0
Update fox.jason.prismjs 4.0.0
Update fox.jason.readthedocs 4.0.0

## Motivation and Context

DITA-OT 4.0 introduces **breaking changes**  which have affected these plugins. Specifically, the requirement for Java 17 removes the Nashorn engine and use of `<script>` from ANT which means that Node.js is now mandatory for the Prism plug-in. The Unit-Test plugin has a feature update to replicate a tweak that had been written using `<script>` previously,
The audiobook had been using  -   `preprocess.copy-image.skip` which has been amended to `build-step.copy-image=false`. readthedocs has a similar bug fix using `build-step.copy-image=false`

All Previous  `fox.jason.audiobook` 1.x  and `fox.jason.prismjs` 1.x, 2.x and 3.x are **not compatible** with DITA-OT 4.0

## How Has This Been Tested?

Unit testing, manual testing

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>

