### PR TITLE
Add org.doctales.graal

### DIFF
--- a/org.doctales.graal.json
+++ b/org.doctales.graal.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "org.doctales.graal",
+    "description": "Utility plugin which provides the Graal VM. The Graal VM is needed to execute JavaScript in Apache Ant.",
+    "keywords": ["Ant"],
+    "homepage": "https://github.com/doctales/org.doctales.graal/",
+    "vers": "20.2.0",
+    "license": "GPL2",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=1.0.0"
+      }
+    ],
+    "url": "https://github.com/doctales/org.doctales.graal/archive/refs/tags/20.2.0.zip",
+    "cksum": "5b399e1aa717d00154e9adfa433004b289635770f6c1e722ff924a6994ec9759"
+  }
+]


### PR DESCRIPTION
## Description
Added the org.doctales.graal plugin, which provides the Graal VM, which is needed to execute JavaScript with Apache Ant.