### PR TITLE
add com.synopsys.mapref-topichead version 1.0.0

### DIFF
--- a/com.synopsys.mapref-topichead.json
+++ b/com.synopsys.mapref-topichead.json
@@ -1,0 +1,24 @@
+[
+  {
+    "name": "com.synopsys.mapref-topichead",
+    "description": "Create <topichead> navigation hierarchy from submap titles instead of discarding them.",
+    "keywords": [
+      "mapref",
+      "navigation",
+      "submaps",
+      "titles",
+      "topichead"
+    ],
+    "homepage": "https://github.com/chrispy-snps/DITA-mapref-topichead/",
+    "vers": "1.0.0",
+    "license": "GPL-3.0-or-later",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.7.0"
+      }
+    ],
+    "url": "https://github.com/chrispy-snps/DITA-mapref-topichead/releases/download/1.0.0/com.synopsys.mapref-topichead-1.0.0.zip",
+    "cksum": "6ce413c3d7431d1bbfc4a957c1dcb71f6df171c1ba94095a0504da93c379b3e1"
+  }
+]


### PR DESCRIPTION
## Description
Add the `com.synopsys.mapref-topichead` plugin to the registry (my first registered plugin!).

Please let me know if the angle brackets in the `description` field need to be escaped for proper display in the web interface.

## Motivation and Context
Support the registry, make the plugin easier to install.

## How Has This Been Tested?
I ran the example in the plugin repository, plus we use this extensively in our own publishing flow.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
The plugin is documented at its repository page.

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>