### PR TITLE
Plugin Release Updates

### DIFF
--- a/fox.jason.extend.css.json
+++ b/fox.jason.extend.css.json
@@ -150,5 +150,24 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.extend.css/archive/v1.2.2.zip",
     "cksum": "af1af7e73ec3f24e3c77e17f432c9037abe4183900f9ad6b6e004b91e5957b25"
+  },
+  {
+    "name": "fox.jason.extend.css",
+    "description": "Extension to allow additional plug-ins to add an extra CSS stylesheet to HTML pages.",
+    "keywords": [
+      "html",
+      "css"
+    ],
+    "homepage": "https://jason-fox.github.io/fox.jason.extend.css",
+    "vers": "1.3.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.1.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.extend.css/archive/v1.3.0.zip",
+    "cksum": "7a70b73fd3b8aaa03e9fd03cb525946c68be56afae155895ed03e21cf4ba450c"
   }
 ]

--- a/fox.jason.favicon.json
+++ b/fox.jason.favicon.json
@@ -36,5 +36,24 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.favicon/archive/v1.0.1.zip",
     "cksum": "4ae086ce039f18df392601f27cd6dc8b379544dc1d6e882a9c56d983c836bd4d"
+  },
+  {
+    "name": "fox.jason.favicon",
+    "description": "Adds a favicon to DITA HTML output.",
+    "keywords": [
+      "html",
+      "css"
+    ],
+    "homepage": "https://jason-fox.github.io/fox.jason.favicon",
+    "vers": "1.1.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.1.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.favicon/archive/v1.1.0.zip",
+    "cksum": "0a08147da40110c9addaec9a4d596f37c72d7df3d4b5e1121ea4200bd688657e"
   }
 ]

--- a/fox.jason.open-graph.json
+++ b/fox.jason.open-graph.json
@@ -18,5 +18,25 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.open-graph/archive/v1.0.0.zip",
     "cksum": "66ab41ade08594dc593940b7b2989962f5e973204085a7d79ba293a42739f04c"
+  },
+  {
+    "name": "fox.jason.open-graph",
+    "description": "Adds Open-Graph social media metadata to DITA HTML output.",
+    "keywords": [
+      "twitter",
+      "facebook",
+      "open-graph"
+    ],
+    "homepage": "https://jason-fox.github.io/fox.jason.open-graph",
+    "vers": "1.1.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.1.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.open-graph/archive/v1.1.0.zip",
+    "cksum": "9ce9a46848b6a1e3a60b988adddd785939f9eabe1265d79957a291f03002a829"
   }
 ]

--- a/fox.jason.translate.xliff.json
+++ b/fox.jason.translate.xliff.json
@@ -220,5 +220,24 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.translate.xliff/archive/v4.0.0.zip",
     "cksum": "262077e610642ebbf42309af4b067ad8de47e3054220a501a5077c9caf399ee2"
+  },
+  {
+    "name": "fox.jason.translate.xliff",
+    "description": "Creates XLIFF from DITA, auto-translates and re-merges XLIFF files, generating translated documentation in a targeted foreign language.",
+    "keywords": [
+      "xliff",
+      "language-translation"
+    ],
+    "homepage": "https://jason-fox.github.io/fox.jason.translate.xliff",
+    "vers": "4.1.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.translate.xliff/archive/v4.1.0.zip",
+    "cksum": "838397d46bac59efdcdf62a36054672979112e14cce248013bc70e0841b44e92"
   }
 ]

--- a/fox.jason.watermark.json
+++ b/fox.jason.watermark.json
@@ -36,5 +36,24 @@
     ],
     "url": "https://github.com/jason-fox/fox.jason.watermark/archive/v1.0.1.zip",
     "cksum": "5bf6819d20a67c376b620b3767a0ce094e5727c222282cb2a410e3aae84c7dd6"
+  },
+  {
+    "name": "fox.jason.watermark",
+    "description": "Defaces draft PDFs with a watermark image",
+    "keywords": [
+      "watermark",
+      "pdf"
+    ],
+    "homepage": "https://jason-fox.github.io/fox.jason.watermark",
+    "vers": "2.0.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.0.0"
+      }
+    ],
+    "url": "https://github.com/jason-fox/fox.jason.watermark/archive/v2.0.0.zip",
+    "cksum": "26d94e17eb57ae68d6dfb953df92d770f6c57f8c9db32ac5c4a68d46019a0950"
   }
 ]


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail. -->
- Update fox.jason.extend.css to 1.3.0
- Update fox.jason.open-graph to 1.1.0 
- Update fox.jason.translate.xliff to 4.1.0
- Update fox.jason.favicon to 1.1.0
- Update fox.jason.watermark to 2.0.0


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, add a link to the issue number: Fixes #1234. -->

New releases, primarily to ensure map-first preprocessing compatibility.
Switching to use  `depend.preprocess.post` endpoint.

## How Has This Been Tested?
<!-- Include details of your testing environment, and the tests that you ran -->
<!-- to verify the effect your changes will have on other areas of the code. -->
Local testing

## Type of Changes
<!-- What type of changes does your code introduce? -->
<!-- (Remove inapplicable items) -->

- Bug fix _(non-breaking change which fixes an issue)_
- New feature _(non-breaking change which adds functionality)_
- Breaking change _(fix or feature that changes existing functionality)_

## Documentation and Compatibility
<!-- Describe whether your changes require updates to docs or user plug-ins. -->

- What documentation changes are needed for this feature?
  _(Provide links to existing documentation topics that will require updates)_
- Will this change affect backwards compatibility or other users' overrides?

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.

<!--
Before submitting, check the Preview tab above to verify the XML markup appears
correctly and remember you can edit the description later to add information.
-->
