### PR TITLE
Update DITA Bootstrap plug-ins for 5.3.4

### DIFF
--- a/net.infotexture.dita-bootstrap.extension.json
+++ b/net.infotexture.dita-bootstrap.extension.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "net.infotexture.dita-bootstrap.extension",
+    "description": "Bootstrap Extensions 5.3.0 for DITA Bootstrap 5.3.4",
+    "keywords": ["HTML", "HTML5", "Bootstrap", "Bootstrap 5", "Bootstrap Extensions"],
+    "homepage": "https://infotexture.github.io/dita-bootstrap/search-box.html",
+    "vers": "5.3.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.7.0"
+      },
+      {
+        "name": "net.infotexture.dita-bootstrap",
+        "req": ">=5.3.4"
+      }
+    ],
+    "url": "https://github.com/infotexture/dita-bootstrap.extension/archive/5.3.0.zip",
+    "cksum": "18f299849bbe93ff342abefb41ea007395c451e9023f204eda486d73be02d67d"
+  }
+]

--- a/net.infotexture.dita-bootstrap.json
+++ b/net.infotexture.dita-bootstrap.json
@@ -174,5 +174,25 @@
     ],
     "url": "https://github.com/infotexture/dita-bootstrap/archive/5.3.3.zip",
     "cksum": "b322d1edbcf3dca97e594a889e2ec01f3b396d79b0109cf75448f899a65d0ab1"
+  },
+  {
+    "name": "net.infotexture.dita-bootstrap",
+    "description": "Styled HTML5 output with an extensible Bootstrap template",
+    "keywords": ["HTML", "HTML5", "Bootstrap", "Bootstrap 5", "Responsive"],
+    "homepage": "https://infotexture.github.io/dita-bootstrap",
+    "vers": "5.3.4",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.7.0"
+      },
+      {
+        "name": "fox.jason.extend.css",
+        "req": ">=1.3.0"
+      }
+    ],
+    "url": "https://github.com/infotexture/dita-bootstrap/archive/5.3.4.zip",
+    "cksum": "4cb32dae34d2ea28cf8b70c527078ef9a01d614466b4a4639384f79c39cc4a3e"
   }
 ]

--- a/net.infotexture.dita-bootstrap.lunr.json
+++ b/net.infotexture.dita-bootstrap.lunr.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "net.infotexture.dita-bootstrap.lunr",
-    "description": "Lunr.js search for DITA Bootstrap",
+    "description": "Lunr.js search for DITA Bootstrap 5.3.3",
     "keywords": ["HTML", "HTML5", "Bootstrap", "Bootstrap 5", "Responsive", "Lunr", "Search"],
     "homepage": "https://infotexture.github.io/dita-bootstrap/search-box.html",
     "vers": "5.3.3",
@@ -18,5 +18,25 @@
     ],
     "url": "https://github.com/infotexture/dita-bootstrap.lunr/archive/5.3.3.zip",
     "cksum": "42a820bcae1bf9f903028b928c9f2fea5c5243da07d72f75f4db076ac3f13ce0"
+  },
+  {
+    "name": "net.infotexture.dita-bootstrap.lunr",
+    "description": "Lunr.js search for DITA Bootstrap 5.3.4",
+    "keywords": ["HTML", "HTML5", "Bootstrap", "Bootstrap 5", "Responsive", "Lunr", "Search"],
+    "homepage": "https://infotexture.github.io/dita-bootstrap/search-box.html",
+    "vers": "5.3.4",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.7.0"
+      },
+      {
+        "name": "net.infotexture.dita-bootstrap",
+        "req": ">=5.3.4"
+      }
+    ],
+    "url": "https://github.com/infotexture/dita-bootstrap.lunr/archive/5.3.4.zip",
+    "cksum": "19123d8ceb5fdc2c87aadbc307e4c7e8ef19680b0d5119886977d98db8197e57"
   }
 ]

--- a/net.infotexture.dita-bootstrap.sass.json
+++ b/net.infotexture.dita-bootstrap.sass.json
@@ -18,5 +18,25 @@
     ],
     "url": "https://github.com/infotexture/dita-bootstrap.sass/archive/5.3.3.zip",
     "cksum": "6331f354194e9ca66830a52413c1ccfa2de42f139db646ac4312834b2ecbc921"
+  },
+  {
+    "name": "net.infotexture.dita-bootstrap.sass",
+    "description": "Sass theme customization for DITA Bootstrap 5.3.4",
+    "keywords": ["HTML", "HTML5", "Bootstrap", "Bootstrap 5", "Responsive", "Sass", "Themes"],
+    "homepage": "https://infotexture.github.io/dita-bootstrap/sass.html",
+    "vers": "5.3.4",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.7.0"
+      },
+      {
+        "name": "net.infotexture.dita-bootstrap",
+        "req": ">=5.3.4"
+      }
+    ],
+    "url": "https://github.com/infotexture/dita-bootstrap.sass/archive/5.3.4.zip",
+    "cksum": "24b802fbb887a0bb5809e9d8e532d78462570baca88244cc9d3c770af89860cb"
   }
 ]


### PR DESCRIPTION
Latest versions of [DITA Bootstrap](https://infotexture.github.io/dita-bootstrap/) (5.3.4) and related plug-ins:

- [DITA Bootstrap Lunr Search 5.3.4](https://infotexture.github.io/dita-bootstrap/search-box.html)
- [DITA Bootstrap Sass 5.3.4](https://infotexture.github.io/dita-bootstrap/sass.html)
- [Bootstrap Extensions 5.3.0 for DITA Bootstrap 5.3.4](https://infotexture.github.io/dita-bootstrap.extension/)

cc/ @jason-fox 