### PR TITLE
Update DITA Bootstrap plug-ins for 5.3.5

### DIFF
--- a/net.infotexture.dita-bootstrap.extension.json
+++ b/net.infotexture.dita-bootstrap.extension.json
@@ -1,8 +1,8 @@
 [
   {
     "name": "net.infotexture.dita-bootstrap.extension",
-    "description": "Bootstrap Extensions 5.3.0 for DITA Bootstrap 5.3.4",
-    "keywords": ["HTML", "HTML5", "Bootstrap", "Bootstrap 5", "Bootstrap Extensions"],
+    "description": "Bootstrap extension 5.3.0 for DITA Bootstrap 5.3.4",
+    "keywords": ["HTML", "HTML5", "Bootstrap", "Bootstrap 5", "Bootstrap extension"],
     "homepage": "https://infotexture.github.io/dita-bootstrap/search-box.html",
     "vers": "5.3.0",
     "license": "Apache-2.0",
@@ -18,5 +18,25 @@
     ],
     "url": "https://github.com/infotexture/dita-bootstrap.extension/archive/5.3.0.zip",
     "cksum": "18f299849bbe93ff342abefb41ea007395c451e9023f204eda486d73be02d67d"
+  },
+  {
+    "name": "net.infotexture.dita-bootstrap.extension",
+    "description": "Bootstrap extension 5.3.1 for DITA Bootstrap 5.3.5",
+    "keywords": ["HTML", "HTML5", "Bootstrap", "Bootstrap 5", "Bootstrap extension"],
+    "homepage": "https://infotexture.github.io/dita-bootstrap/search-box.html",
+    "vers": "5.3.1",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.7.0"
+      },
+      {
+        "name": "net.infotexture.dita-bootstrap",
+        "req": ">=5.3.5"
+      }
+    ],
+    "url": "https://github.com/infotexture/dita-bootstrap.extension/archive/5.3.1.zip",
+    "cksum": "73cc3f218cc567c586660dcce59a784c68d2838508be500abb0a25c740c62cf0"
   }
 ]

--- a/net.infotexture.dita-bootstrap.json
+++ b/net.infotexture.dita-bootstrap.json
@@ -194,5 +194,25 @@
     ],
     "url": "https://github.com/infotexture/dita-bootstrap/archive/5.3.4.zip",
     "cksum": "4cb32dae34d2ea28cf8b70c527078ef9a01d614466b4a4639384f79c39cc4a3e"
+  },
+  {
+    "name": "net.infotexture.dita-bootstrap",
+    "description": "Styled HTML5 output with an extensible Bootstrap template",
+    "keywords": ["HTML", "HTML5", "Bootstrap", "Bootstrap 5", "Responsive"],
+    "homepage": "https://infotexture.github.io/dita-bootstrap",
+    "vers": "5.3.5",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.7.0"
+      },
+      {
+        "name": "fox.jason.extend.css",
+        "req": ">=1.3.0"
+      }
+    ],
+    "url": "https://github.com/infotexture/dita-bootstrap/archive/5.3.5.zip",
+    "cksum": "83f4240662a439f32c2be9297591b55cb22490396a1dcb42dc6634e1c591d7c2"
   }
 ]

--- a/net.infotexture.dita-bootstrap.lunr.json
+++ b/net.infotexture.dita-bootstrap.lunr.json
@@ -38,5 +38,25 @@
     ],
     "url": "https://github.com/infotexture/dita-bootstrap.lunr/archive/5.3.4.zip",
     "cksum": "19123d8ceb5fdc2c87aadbc307e4c7e8ef19680b0d5119886977d98db8197e57"
+  },
+  {
+    "name": "net.infotexture.dita-bootstrap.lunr",
+    "description": "Lunr.js search for DITA Bootstrap 5.3.5",
+    "keywords": ["HTML", "HTML5", "Bootstrap", "Bootstrap 5", "Responsive", "Lunr", "Search"],
+    "homepage": "https://infotexture.github.io/dita-bootstrap/search-box.html",
+    "vers": "5.3.5",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.7.0"
+      },
+      {
+        "name": "net.infotexture.dita-bootstrap",
+        "req": ">=5.3.5"
+      }
+    ],
+    "url": "https://github.com/infotexture/dita-bootstrap.lunr/archive/5.3.5.zip",
+    "cksum": "dc7b910be77812a77e7467709c0c6e18d401d8158c18368b43eb1ce8d5e1b84a"
   }
 ]

--- a/net.infotexture.dita-bootstrap.sass.json
+++ b/net.infotexture.dita-bootstrap.sass.json
@@ -38,5 +38,25 @@
     ],
     "url": "https://github.com/infotexture/dita-bootstrap.sass/archive/5.3.4.zip",
     "cksum": "24b802fbb887a0bb5809e9d8e532d78462570baca88244cc9d3c770af89860cb"
+  },
+  {
+    "name": "net.infotexture.dita-bootstrap.sass",
+    "description": "Sass theme customization for DITA Bootstrap 5.3.5",
+    "keywords": ["HTML", "HTML5", "Bootstrap", "Bootstrap 5", "Responsive", "Sass", "Themes"],
+    "homepage": "https://infotexture.github.io/dita-bootstrap/sass.html",
+    "vers": "5.3.5",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.7.0"
+      },
+      {
+        "name": "net.infotexture.dita-bootstrap",
+        "req": ">=5.3.5"
+      }
+    ],
+    "url": "https://github.com/infotexture/dita-bootstrap.sass/archive/5.3.5.zip",
+    "cksum": "70e34ab4d3178e75e2eae1522a39c0d162f0cf2ca8e82718d0e4cbffec54f229"
   }
 ]

--- a/net.infotexture.dita-bootstrap.table.json
+++ b/net.infotexture.dita-bootstrap.table.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "net.infotexture.dita-bootstrap.table",
+    "description": "Bootstrap Table 1.22.4 for DITA Bootstrap 5.3.5",
+    "keywords": ["HTML", "HTML5", "Bootstrap", "Bootstrap 5", "Bootstrap Table"],
+    "homepage": "https://infotexture.github.io/dita-bootstrap/bootstrap-table.html",
+    "vers": "1.22.4",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.7.0"
+      },
+      {
+        "name": "net.infotexture.dita-bootstrap",
+        "req": ">=5.3.5"
+      }
+    ],
+    "url": "https://github.com/infotexture/dita-bootstrap.table/archive/1.22.4.zip",
+    "cksum": "da381179adae1859bb88324c5dbab152b9f37eef7dca2cf153d9cef7db5e2084"
+  }
+]


### PR DESCRIPTION
## Description

Latest versions of [DITA Bootstrap](https://infotexture.github.io/dita-bootstrap/) (5.3.5) and related plug-ins:

- [DITA Bootstrap Lunr Search 5.3.5](https://infotexture.github.io/dita-bootstrap/search-box.html)
- [DITA Bootstrap Sass 5.3.5](https://infotexture.github.io/dita-bootstrap/sass.html)
- [Bootstrap extension 5.3.1 for DITA Bootstrap 5.3.5](https://infotexture.github.io/dita-bootstrap/bootstrap-extension.html)
- [Bootstrap Table 1.22.4 for DITA Bootstrap 5.3.5](https://infotexture.github.io/dita-bootstrap/bootstrap-table.html)

cc/ @jason-fox 
