### PR TITLE
Update DITA Bootstrap plug-ins for 5.3.8

### DIFF
--- a/net.infotexture.dita-bootstrap.extension.json
+++ b/net.infotexture.dita-bootstrap.extension.json
@@ -3,7 +3,7 @@
     "name": "net.infotexture.dita-bootstrap.extension",
     "description": "Bootstrap extension 5.3.0 for DITA Bootstrap 5.3.4",
     "keywords": ["HTML", "HTML5", "Bootstrap", "Bootstrap 5", "Bootstrap extension"],
-    "homepage": "https://infotexture.github.io/dita-bootstrap/search-box.html",
+    "homepage": "https://infotexture.github.io/dita-bootstrap.extension",
     "vers": "5.3.0",
     "license": "Apache-2.0",
     "deps": [
@@ -23,7 +23,7 @@
     "name": "net.infotexture.dita-bootstrap.extension",
     "description": "Bootstrap extension 5.3.1 for DITA Bootstrap 5.3.5",
     "keywords": ["HTML", "HTML5", "Bootstrap", "Bootstrap 5", "Bootstrap extension"],
-    "homepage": "https://infotexture.github.io/dita-bootstrap/search-box.html",
+    "homepage": "https://infotexture.github.io/dita-bootstrap.extension",
     "vers": "5.3.1",
     "license": "Apache-2.0",
     "deps": [

--- a/net.infotexture.dita-bootstrap.json
+++ b/net.infotexture.dita-bootstrap.json
@@ -214,5 +214,65 @@
     ],
     "url": "https://github.com/infotexture/dita-bootstrap/archive/5.3.5.zip",
     "cksum": "83f4240662a439f32c2be9297591b55cb22490396a1dcb42dc6634e1c591d7c2"
+  },
+  {
+    "name": "net.infotexture.dita-bootstrap",
+    "description": "Styled HTML5 output with an extensible Bootstrap template",
+    "keywords": ["HTML", "HTML5", "Bootstrap", "Bootstrap 5", "Responsive"],
+    "homepage": "https://infotexture.github.io/dita-bootstrap",
+    "vers": "5.3.5.1",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.7.0"
+      },
+      {
+        "name": "fox.jason.extend.css",
+        "req": ">=1.3.0"
+      }
+    ],
+    "url": "https://github.com/infotexture/dita-bootstrap/archive/5.3.5.1.zip",
+    "cksum": "57cfdf35db4144c45fdab068bfceb398de63a4481eae1bf85d3041e8a41f9e3a"
+  },
+  {
+    "name": "net.infotexture.dita-bootstrap",
+    "description": "Styled HTML5 output with an extensible Bootstrap template",
+    "keywords": ["HTML", "HTML5", "Bootstrap", "Bootstrap 5", "Responsive"],
+    "homepage": "https://infotexture.github.io/dita-bootstrap",
+    "vers": "5.3.6",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.7.0"
+      },
+      {
+        "name": "fox.jason.extend.css",
+        "req": ">=1.3.0"
+      }
+    ],
+    "url": "https://github.com/infotexture/dita-bootstrap/archive/5.3.6.zip",
+    "cksum": "e53c6ec15fe68092d28297a49b35534ce89aa2b422a2563c23bba2373789be1c"
+  },
+  {
+    "name": "net.infotexture.dita-bootstrap",
+    "description": "Styled HTML5 output with an extensible Bootstrap template",
+    "keywords": ["HTML", "HTML5", "Bootstrap", "Bootstrap 5", "Responsive"],
+    "homepage": "https://infotexture.github.io/dita-bootstrap",
+    "vers": "5.3.8",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.7.0"
+      },
+      {
+        "name": "fox.jason.extend.css",
+        "req": ">=1.3.0"
+      }
+    ],
+    "url": "https://github.com/infotexture/dita-bootstrap/archive/5.3.8.zip",
+    "cksum": "3e95aa3fbdc3a30a33e39ac8d99c297358a6253bb397037e4bdddd6f5878d9d3"
   }
 ]

--- a/net.infotexture.dita-bootstrap.lunr.json
+++ b/net.infotexture.dita-bootstrap.lunr.json
@@ -58,5 +58,25 @@
     ],
     "url": "https://github.com/infotexture/dita-bootstrap.lunr/archive/5.3.5.zip",
     "cksum": "dc7b910be77812a77e7467709c0c6e18d401d8158c18368b43eb1ce8d5e1b84a"
+  },
+  {
+    "name": "net.infotexture.dita-bootstrap.lunr",
+    "description": "Lunr.js search for DITA Bootstrap 5.3.6",
+    "keywords": ["HTML", "HTML5", "Bootstrap", "Bootstrap 5", "Responsive", "Lunr", "Search"],
+    "homepage": "https://infotexture.github.io/dita-bootstrap/search-box.html",
+    "vers": "5.3.6",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.7.0"
+      },
+      {
+        "name": "net.infotexture.dita-bootstrap",
+        "req": ">=5.3.6"
+      }
+    ],
+    "url": "https://github.com/infotexture/dita-bootstrap.lunr/archive/5.3.6.zip",
+    "cksum": "fe330d7635b9d6626d54208fcc3a36123afe8fcd87db0cbbab5ba116d242bdc1"
   }
 ]

--- a/net.infotexture.dita-bootstrap.table.json
+++ b/net.infotexture.dita-bootstrap.table.json
@@ -18,5 +18,25 @@
     ],
     "url": "https://github.com/infotexture/dita-bootstrap.table/archive/1.22.4.zip",
     "cksum": "da381179adae1859bb88324c5dbab152b9f37eef7dca2cf153d9cef7db5e2084"
+  },
+  {
+    "name": "net.infotexture.dita-bootstrap.table",
+    "description": "Bootstrap Table 1.25.0 for DITA Bootstrap 5.3.6",
+    "keywords": ["HTML", "HTML5", "Bootstrap", "Bootstrap 5", "Bootstrap Table"],
+    "homepage": "https://infotexture.github.io/dita-bootstrap/bootstrap-table.html",
+    "vers": "1.25.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.7.0"
+      },
+      {
+        "name": "net.infotexture.dita-bootstrap",
+        "req": ">=5.3.6"
+      }
+    ],
+    "url": "https://github.com/infotexture/dita-bootstrap.table/archive/1.25.0.zip",
+    "cksum": "0c67d391f86e3d4386742a256be5d055dc9ac1b0e6fdba50a71e528a422a837d"
   }
 ]


### PR DESCRIPTION
Latest versions of [DITA Bootstrap](https://infotexture.github.io/dita-bootstrap/) (5.3.8) and related plug-ins:

- [DITA Bootstrap Lunr Search 5.3.6](https://infotexture.github.io/dita-bootstrap/search-box.html)
- [Bootstrap Table 1.25.0 for DITA Bootstrap 5.3.6](https://infotexture.github.io/dita-bootstrap/bootstrap-table.html)

Fix homepage link for [Bootstrap extension](https://infotexture.github.io/dita-bootstrap/bootstrap-extension.html)