### PR TITLE
Unwrap alias entries

### DIFF
--- a/org.doctales.ant-contrib.json
+++ b/org.doctales.ant-contrib.json
@@ -1,5 +1,3 @@
-[
-  {
-    "alias": "org.jung.ant-contrib"
-  }
-]
+{
+  "alias": "org.jung.ant-contrib"
+}

--- a/org.doctales.schematron.json
+++ b/org.doctales.schematron.json
@@ -1,5 +1,3 @@
-[
-  {
+{
   "alias": "org.jung.schematron"
-  }
-]
+}

--- a/org.doctales.terminology.json
+++ b/org.doctales.terminology.json
@@ -1,5 +1,3 @@
-[
-  {
-    "alias": "org.jung.terminology"
-  }
-]
+{
+  "alias": "org.jung.terminology"
+}


### PR DESCRIPTION
Remove the outer array from the 3 JSON files that wrap a single alias object in an array, which currently prevents the **Plugins** page at [dita-ot.org/plugins](https://www.dita-ot.org/plugins) from loading properly.

This amends the initial alias entries for the renamed `doctales` plug-ins from the following PRs and converts them to plain objects to match the pattern used by the other alias files:

- https://github.com/dita-ot/registry/pull/157
- https://github.com/dita-ot/registry/pull/158
- https://github.com/dita-ot/registry/pull/159

Closes https://github.com/dita-ot/website/pull/939 per https://github.com/dita-ot/website/pull/939#issuecomment-3935427783.

