### PR TITLE
iiRDS plugin 1.1

### DIFF
--- a/org.iirds.dita.package.json
+++ b/org.iirds.dita.package.json
@@ -45,6 +45,6 @@
       
     ],
     "url": "https://www.iirds.org/fileadmin/downloads/DITA/org.iirds.dita.package-1.1.0.zip",
-    "cksum": "5517B45D64B8523D69FA35AD07A0DBA98F5A8793B0A0B8884E30675DBF343ED"
+    "cksum": "5517B45D64B8523D69FA35AD07A0DBA98F5A8793B0A0B8884E30675DBF343ED1"
   }
  ]

--- a/org.iirds.dita.package.json
+++ b/org.iirds.dita.package.json
@@ -22,5 +22,29 @@
     ],
     "url": "https://www.iirds.org/fileadmin/downloads/DITA/org.iirds.dita.package-1.0.0.zip",
     "cksum": "567574EE8BBF7471511BBCC3E73940477D9BD914ECA0FE0E39F8651E5CDD7938"
+  },
+  {
+    "name": "org.iirds.dita.package",
+    "description": "Generates iiRDS (1.3) packages with HTML content",
+    "keywords": [
+      "iiRDS",
+      "intelligent information Request and Delivery Standard"
+    ],
+    "homepage": "https://www.iirds.org/tools/dita-plugin/",
+    "vers": "1.1.0",
+    "license": "Apache-2.0",
+    "deps": [
+      {
+        "name": "org.dita.base",
+        "req": ">=3.7.3"
+      },
+      {
+        "name": "org.dita.html5",
+        "req": ">=3.7.3"
+      }
+      
+    ],
+    "url": "https://www.iirds.org/fileadmin/downloads/DITA/org.iirds.dita.package-1.1.0.zip",
+    "cksum": "5517B45D64B8523D69FA35AD07A0DBA98F5A8793B0A0B8884E30675DBF343ED"
   }
  ]


### PR DESCRIPTION
## Description
New version of iiRDS  Plugin

## Motivation and Context
Generated iiRDS packages from DITA

## How Has This Been Tested?
Locally tested on Windows systems with DITA OT 3.7.1, 4.1.1, 4.4
Additional there are some unit tests in the code or the plugin

## Type of Changes
* Adds support for DITA OT 4.x
* Add support for subject schemes for iiRDS metadata taxonomy management
* No breaking changes

## Documentation and Compatibility
The plugin contains documentation in PDF format, doc sources (DITA format) are included, too
The documentation of the plugin has been updated according to the changes of the plugin
